### PR TITLE
LANTERNA-fix split panel cleanup TerminalPosition, reduce object memo…

### DIFF
--- a/src/examples/java/com/googlecode/lanterna/examples/DrawRectangle.java
+++ b/src/examples/java/com/googlecode/lanterna/examples/DrawRectangle.java
@@ -29,8 +29,7 @@ public class DrawRectangle {
 		screen.startScreen();
 		screen.clear();
 
-		tGraphics.drawRectangle(
-			new TerminalPosition(3,3), new TerminalSize(10,10), '*');
+		tGraphics.drawRectangle(TerminalPosition.of(3,3), TerminalSize.of(10,10), '*');
 		screen.refresh();
 
 		screen.readInput();

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -38,7 +38,7 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     public final int column;
     public final int row;
     /**
-     * @return a new TerminalPosition instance with the supplied column and row
+     * @return a TerminalPosition instance with the supplied column and row
      */
     public static final TerminalPosition of(int column, int row) {
         if(column == 0 && row == 0) {
@@ -59,7 +59,7 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return Either this instance, or a new instance if column/row are different than this instance's column/row.
      */
     public TerminalPosition as(int column, int row) {
-        return (column != this.column || row != this.row) ? of(column, row) : this;
+        return (column == this.column && row == this.row) ? this : of(column, row);
     }
     /**
      * Returns itself if it is equal to the supplied position, otherwise the supplied position. You can use this if you
@@ -98,60 +98,59 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
         return row;
     }
     /**
-     * Creates a new TerminalPosition object representing a position with the same row index as this but with a
-     * supplied column index.
-     * @param column Index of the column for the new position
-     * @return A TerminalPosition object with the same row as this but with a specified column index
+     * Obtain a TerminalPosition with the supplied column and the same row as this instance.
+     * @param column Index of the column for the resulting TerminalPosition
+     * @return a TerminalPosition object with the same row as this but with a specified column index
      */
     public TerminalPosition withColumn(int column) {
         return as(column, row);
     }
     /**
-     * Creates a new TerminalPosition object representing a position with the same column index as this but with a
-     * supplied row index.
+     * Obtain a TerminalPosition object with this instance's column and the supplied row.
      * @param row Index of the row for the new position
-     * @return A TerminalPosition object with the same column as this but with a specified row index
+     * @return a TerminalPosition object with the same column as this but with a specified row index
      */
     public TerminalPosition withRow(int row) {
         return as(column, row);
     }
     /**
-     * Creates a new TerminalPosition object representing a position on the same row, but with a column offset by a
-     * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
-     * a terminal position <i>delta</i> number of columns to the right and for negative numbers the same to the left.
+     * Obtain a TerminalPosition with a column offset by the supplied delta and the same row as this instance.
+     * Calling this method with delta 0 will return this, calling it with a positive delta will return
+     * a TerminalPosition <i>delta</i> number of columns to the right and for negative numbers the same to the left.
      * @param delta Column offset
-     * @return New terminal position based off this one but with an applied offset
+     * @return a TerminalPosition based off this one but with an applied offset
      */
     public TerminalPosition withRelativeColumn(int delta) {
         return plus(delta, 0);
     }
     /**
-     * Creates a new TerminalPosition object representing a position on the same column, but with a row offset by a
-     * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
-     * a terminal position <i>delta</i> number of rows to the down and for negative numbers the same up.
+     * Obtain a TerminalPosition with the same column as this instance and a row which is this instance's row offset
+     * by the supplied delta.
+     * Calling this method with delta 0 will return this, calling it with a positive delta will return
+     * a TerminalPosition <i>delta</i> number of rows to the down and for negative numbers the same up.
      * @param delta Row offset
-     * @return New terminal position based off this one but with an applied offset
+     * @return a TerminalPosition based off this one but with an applied offset
      */
     public TerminalPosition withRelativeRow(int delta) {
         return plus(0, delta);
     }
     /**
-     * Creates a new TerminalPosition object that is 'translated' by an amount of rows and columns specified by another
+     * Obtain a TerminalPosition that is 'translated' by an amount of rows and columns specified by another
      * TerminalPosition. Same as calling
      * <code>withRelativeRow(translate.getRow()).withRelativeColumn(translate.getColumn())</code>
      * @param translate How many columns and rows to translate
-     * @return New TerminalPosition that is the result of the original with added translation
+     * @return a TerminalPosition that is the result of the original with added translation
      */
     public TerminalPosition withRelative(TerminalPosition translate) {
         return plus(translate);
     }
     /**
-     * Creates a new TerminalPosition object that is 'translated' by an amount of rows and columns specified by the two
+     * Obtain a TerminalPosition that is 'translated' by an amount of rows and columns specified by the two
      * parameters. Same as calling
      * <code>withRelativeRow(deltaRow).withRelativeColumn(deltaColumn)</code>
-     * @param deltaColumn How many columns to move from the current position in the new TerminalPosition
-     * @param deltaRow How many rows to move from the current position in the new TerminalPosition
-     * @return New TerminalPosition that is the result of the original position with added translation
+     * @param deltaColumn How many columns to move from the current position in the resulting TerminalPosition
+     * @param deltaRow How many rows to move from the current position in the resulting TerminalPosition
+     * @return a TerminalPosition that is the result of the original position with added translation
      */
     public TerminalPosition withRelative(int deltaColumn, int deltaRow) {
         return plus(deltaColumn, deltaRow);

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -35,6 +35,7 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     public static final TerminalPosition OF_1x0 = new TerminalPosition(1, 0);
     public static final TerminalPosition OF_1x1 = new TerminalPosition(1, 1);
 
+    // one of the benefits of immutable: ease of usage
     public final int column;
     public final int row;
     /**

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -35,8 +35,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     public static final TerminalPosition OF_1x0 = new TerminalPosition(1, 0);
     public static final TerminalPosition OF_1x1 = new TerminalPosition(1, 1);
 
-    private final int column;
-    private final int row;
+    public final int column;
+    public final int row;
     /**
      * @return a new TerminalPosition instance with the supplied column and row
      */
@@ -53,7 +53,7 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
         return new TerminalPosition(column, row);
     }
     /**
-     * Returns a TerminalPositoin with the column and row supplied.
+     * Returns a TerminalPosition with the column and row supplied.
      * If either the column or row supplied is different than this instances column or row, then a new instance is returned.
      * If both column and row are the same as this instance's column and row, then this instance is returned.
      * @return Either this instance, or a new instance if column/row are different than this instance's column/row.
@@ -98,21 +98,21 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
         return row;
     }
     /**
-     * Creates a new TerminalPosition object representing a position with the same column index as this but with a
-     * supplied row index.
-     * @param row Index of the row for the new position
-     * @return A TerminalPosition object with the same column as this but with a specified row index
-     */
-    public TerminalPosition withRow(int row) {
-        return as(column, row);
-    }
-    /**
      * Creates a new TerminalPosition object representing a position with the same row index as this but with a
      * supplied column index.
      * @param column Index of the column for the new position
      * @return A TerminalPosition object with the same row as this but with a specified column index
      */
     public TerminalPosition withColumn(int column) {
+        return as(column, row);
+    }
+    /**
+     * Creates a new TerminalPosition object representing a position with the same column index as this but with a
+     * supplied row index.
+     * @param row Index of the row for the new position
+     * @return A TerminalPosition object with the same column as this but with a specified row index
+     */
+    public TerminalPosition withRow(int row) {
         return as(column, row);
     }
     /**
@@ -221,13 +221,13 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     @Override
     public int hashCode() {
         int hash = 3;
-        hash = 23 * hash + this.row;
         hash = 23 * hash + this.column;
+        hash = 23 * hash + this.row;
         return hash;
     }
 
-    public boolean equals(int columnIndex, int rowIndex) {
-        return column == columnIndex && row == rowIndex;
+    public boolean equals(int column, int row) {
+        return this.column == column && this.row == row;
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -40,18 +40,18 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     /**
      * @return a new TerminalPosition instance with the supplied column and row
      */
-		public static final TerminalPosition of(int column, int row) {
-			if(column == 0 && row == 0) {
-          return OF_0x0;
-      } else if(column == 0 && row == 1) {
-          return OF_0x1;
-      } else if(column == 1 && row == 0) {
-          return OF_1x0;
-      } else if(column == 1 && row == 1) {
-          return OF_1x1;
-      }
-			return new TerminalPosition(column, row);
-		}
+    public static final TerminalPosition of(int column, int row) {
+        if(column == 0 && row == 0) {
+            return OF_0x0;
+        } else if(column == 0 && row == 1) {
+            return OF_0x1;
+        } else if(column == 1 && row == 0) {
+            return OF_1x0;
+        } else if(column == 1 && row == 1) {
+              return OF_1x1;
+        }
+        return new TerminalPosition(column, row);
+    }
 		/**
      * Returns a TerminalPositoin with the column and row supplied.
      * If either the column or row supplied is different than this instances column or row, then a new instance is returned.

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -28,17 +28,49 @@ package com.googlecode.lanterna;
 public class TerminalPosition implements Comparable<TerminalPosition> {
 
     /**
-     * Constant for the top-left corner (0x0)
+     * Constants for less objects memory churn, these are from the top-left corner (column x row)
      */
-    public static final TerminalPosition TOP_LEFT_CORNER = new TerminalPosition(0, 0);
-    /**
-     * Constant for the 1x1 position (one offset in both directions from top-left)
-     */
-    public static final TerminalPosition OFFSET_1x1 = new TerminalPosition(1, 1);
+    public static final TerminalPosition OF_0x0 = new TerminalPosition(0, 0);
+    public static final TerminalPosition OF_0x1 = new TerminalPosition(0, 1);
+    public static final TerminalPosition OF_1x0 = new TerminalPosition(1, 0);
+    public static final TerminalPosition OF_1x1 = new TerminalPosition(1, 1);
 
-    private final int row;
     private final int column;
-
+    private final int row;
+    /**
+     * @return a new TerminalPosition instance with the supplied column and row
+     */
+		public static final TerminalPosition of(int column, int row) {
+			if(column == 0 && row == 0) {
+          return OF_0x0;
+      } else if(column == 0 && row == 1) {
+          return OF_0x1;
+      } else if(column == 1 && row == 0) {
+          return OF_1x0;
+      } else if(column == 1 && row == 1) {
+          return OF_1x1;
+      }
+			return new TerminalPosition(column, row);
+		}
+		/**
+     * Returns a TerminalPositoin with the column and row supplied.
+     * If either the column or row supplied is different than this instances column or row, then a new instance is returned.
+     * If both column and row are the same as this instance's column and row, then this instance is returned.
+     * @return Either this instance, or a new instance if column/row are different than this instance's column/row.
+     */
+		public TerminalPosition as(int column, int row) {
+        return (column != this.column || row != this.row) ? of(column, row) : this;
+    }
+    /**
+     * Returns itself if it is equal to the supplied position, otherwise the supplied position. You can use this if you
+     * have a position field which is frequently recalculated but often resolves to the same; it will keep the same
+     * object in memory instead of swapping it out every cycle.
+     * @param position Position you want to return
+     * @return Itself if this position equals the position passed in, otherwise the position passed in
+     */
+    public TerminalPosition as(TerminalPosition position) {
+        return position == null ? this : as(position.column, position.row);
+    }
     /**
      * Creates a new TerminalPosition object, which represents a location on the screen. There is no check to verify
      * that the position you specified is within the size of the current terminal and you can specify negative positions
@@ -48,10 +80,9 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @param row Row of the location, or the "y" coordinate, zero indexed (the first row is 0)
      */
     public TerminalPosition(int column, int row) {
-        this.row = row;
         this.column = column;
+        this.row = row;
     }
-
     /**
      * Returns the index of the column this position is representing, zero indexed (the first column has index 0).
      * @return Index of the column this position has
@@ -59,7 +90,6 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     public int getColumn() {
         return column;
     }
-
     /**
      * Returns the index of the row this position is representing, zero indexed (the first row has index 0)
      * @return Index of the row this position has
@@ -67,7 +97,6 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     public int getRow() {
         return row;
     }
-
     /**
      * Creates a new TerminalPosition object representing a position with the same column index as this but with a
      * supplied row index.
@@ -75,12 +104,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return A TerminalPosition object with the same column as this but with a specified row index
      */
     public TerminalPosition withRow(int row) {
-        if(row == 0 && this.column == 0) {
-            return TOP_LEFT_CORNER;
-        }
-        return new TerminalPosition(this.column, row);
+        return as(column, row);
     }
-
     /**
      * Creates a new TerminalPosition object representing a position with the same row index as this but with a
      * supplied column index.
@@ -88,12 +113,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return A TerminalPosition object with the same row as this but with a specified column index
      */
     public TerminalPosition withColumn(int column) {
-        if(column == 0 && this.row == 0) {
-            return TOP_LEFT_CORNER;
-        }
-        return new TerminalPosition(column, this.row);
+        return as(column, row);
     }
-
     /**
      * Creates a new TerminalPosition object representing a position on the same row, but with a column offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
@@ -102,12 +123,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return New terminal position based off this one but with an applied offset
      */
     public TerminalPosition withRelativeColumn(int delta) {
-        if(delta == 0) {
-            return this;
-        }
-        return withColumn(column + delta);
+        return plus(delta, 0);
     }
-
     /**
      * Creates a new TerminalPosition object representing a position on the same column, but with a row offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
@@ -116,12 +133,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return New terminal position based off this one but with an applied offset
      */
     public TerminalPosition withRelativeRow(int delta) {
-        if(delta == 0) {
-            return this;
-        }
-        return withRow(row + delta);
+        return plus(0, delta);
     }
-
     /**
      * Creates a new TerminalPosition object that is 'translated' by an amount of rows and columns specified by another
      * TerminalPosition. Same as calling
@@ -130,9 +143,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return New TerminalPosition that is the result of the original with added translation
      */
     public TerminalPosition withRelative(TerminalPosition translate) {
-        return withRelative(translate.getColumn(), translate.getRow());
+        return plus(translate);
     }
-
     /**
      * Creates a new TerminalPosition object that is 'translated' by an amount of rows and columns specified by the two
      * parameters. Same as calling
@@ -142,9 +154,8 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return New TerminalPosition that is the result of the original position with added translation
      */
     public TerminalPosition withRelative(int deltaColumn, int deltaRow) {
-        return withRelativeRow(deltaRow).withRelativeColumn(deltaColumn);
+        return plus(deltaColumn, deltaRow);
     }
-
     /**
      * Returns itself if it is equal to the supplied position, otherwise the supplied position. You can use this if you
      * have a position field which is frequently recalculated but often resolves to the same; it will keep the same
@@ -153,60 +164,53 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
      * @return Itself if this position equals the position passed in, otherwise the position passed in
      */
     public TerminalPosition with(TerminalPosition position) {
-        if(equals(position)) {
-            return this;
-        }
-        return position;
+        return as(position);
     }
-
-    public TerminalPosition plus(TerminalPosition position) {
-        return withRelative(position);
+    public TerminalPosition plus(TerminalPosition other) {
+        return plus(other.column, other.row);
     }
-    
-    public TerminalPosition minus(TerminalPosition position) {
-        return withRelative(-position.getColumn(), -position.getRow());
+    public TerminalPosition minus(TerminalPosition other) {
+        return minus(other.column, other.row);
     }
-    
-    public TerminalPosition multiply(TerminalPosition position) {
-        return new TerminalPosition(column * position.column, row * position.row);
+    public TerminalPosition multiply(TerminalPosition other) {
+        return multiply(other.column, other.row);
     }
-    
     public TerminalPosition divide(TerminalPosition denominator) {
-        return new TerminalPosition(column / denominator.column, row / denominator.row);
+        return divide(denominator.column, denominator.row);
     }
+    public TerminalPosition plus(int column, int row) {
+        return as(this.column + column, this.row + row);
+    }
+    public TerminalPosition minus(int column, int row) {
+        return as(this.column - column, this.row - row);
+    }
+    public TerminalPosition multiply(int column, int row) {
+        return as(this.column * column, this.row * row);
+    }
+    public TerminalPosition divide(int columnsDenominator, int rowsDenominator) {
+        return as(column / columnsDenominator, row / rowsDenominator);
+    }
+    public TerminalPosition plus(int amount)        { return plus(amount, amount); }
+    public TerminalPosition minus(int amount)       { return minus(amount, amount); }
+    public TerminalPosition multiply(int amount)    { return multiply(amount, amount); }
+    public TerminalPosition divide(int denominator) { return divide(denominator, denominator); }
     
     public TerminalPosition abs() {
-        int x = Math.abs(column);
-        int y = Math.abs(row);
-        return new TerminalPosition(x, y);
+        return as(Math.abs(column), Math.abs(row));
     }
     
     public TerminalPosition min(TerminalPosition position) {
-        int x = Math.min(column, position.column);
-        int y = Math.min(row, position.row);
-        return new TerminalPosition(x, y);
+        return as(Math.min(column, position.column), Math.min(row, position.row));
     }
     
     public TerminalPosition max(TerminalPosition position) {
-        int x = Math.max(column, position.column);
-        int y = Math.max(row, position.row);
-        return new TerminalPosition(x, y);
+        return as(Math.max(column, position.column), Math.max(row, position.row));
     }
 
     @Override
-    public int compareTo(TerminalPosition o) {
-        if(row < o.row) {
-            return -1;
-        }
-        else if(row == o.row) {
-            if(column < o.column) {
-                return -1;
-            }
-            else if(column == o.column) {
-                return 0;
-            }
-        }
-        return 1;
+    public int compareTo(TerminalPosition other) {
+        int result = Integer.compare(row, other.row);
+        return result != 0 ? result : Integer.compare(column, other.column);
     }
 
     @Override
@@ -223,19 +227,15 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
     }
 
     public boolean equals(int columnIndex, int rowIndex) {
-        return this.column == columnIndex &&
-                this.row == rowIndex;
+        return column == columnIndex && row == rowIndex;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final TerminalPosition other = (TerminalPosition) obj;
-        return this.row == other.row && this.column == other.column;
+        return obj != null
+            && obj.getClass() == getClass()
+            && ((TerminalPosition) obj).column == column
+            && ((TerminalPosition) obj).row == row
+            ;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/TerminalPosition.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalPosition.java
@@ -52,13 +52,13 @@ public class TerminalPosition implements Comparable<TerminalPosition> {
         }
         return new TerminalPosition(column, row);
     }
-		/**
+    /**
      * Returns a TerminalPositoin with the column and row supplied.
      * If either the column or row supplied is different than this instances column or row, then a new instance is returned.
      * If both column and row are the same as this instance's column and row, then this instance is returned.
      * @return Either this instance, or a new instance if column/row are different than this instance's column/row.
      */
-		public TerminalPosition as(int column, int row) {
+    public TerminalPosition as(int column, int row) {
         return (column != this.column || row != this.row) ? of(column, row) : this;
     }
     /**

--- a/src/main/java/com/googlecode/lanterna/TerminalRectangle.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalRectangle.java
@@ -47,13 +47,24 @@ public class TerminalRectangle {
      * @param height number of rows
      */
     public TerminalRectangle(int x, int y, int width, int height) {
-        position = new TerminalPosition(x, y);
+        position = TerminalPosition.of(x, y);
         size = new TerminalSize(width, height);
         
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
+        this.xAndWidth = x + width;
+        this.yAndHeight = y + height;
+    }
+    public TerminalRectangle(TerminalPosition position, TerminalSize size) {
+        this.position = position;
+        this.size = size;
+
+        this.x = position.getColumn();
+        this.y = position.getRow();
+        this.width = size.getColumns();
+        this.height = size.getRows();
         this.xAndWidth = x + width;
         this.yAndHeight = y + height;
     }
@@ -94,7 +105,10 @@ public class TerminalRectangle {
         return whenContains(p.getColumn(), p.getRow(), op);
     }
     public boolean whenContains(int x, int y, Runnable op) {
-        if (this.x <= x && x < this.xAndWidth && this.y <= y && y < this.yAndHeight) {
+        return whenContains(this.x, this.y, width, height, x, y, op);
+    }
+		public static final boolean whenContains(int rx, int ry, int rw, int rh, int x, int y, Runnable op) {
+        if (rx <= x && x < (rx + rw) && ry <= y && y < (ry + rh)) {
             op.run();
             return true;
         }

--- a/src/main/java/com/googlecode/lanterna/TerminalRectangle.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalRectangle.java
@@ -48,7 +48,7 @@ public class TerminalRectangle {
      */
     public TerminalRectangle(int x, int y, int width, int height) {
         position = TerminalPosition.of(x, y);
-        size = new TerminalSize(width, height);
+        size = TerminalSize.of(width, height);
         
         this.x = x;
         this.y = y;

--- a/src/main/java/com/googlecode/lanterna/TerminalSize.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalSize.java
@@ -24,149 +24,134 @@ package com.googlecode.lanterna;
  *
  * @author Martin
  */
-public class TerminalSize {
-    public static final TerminalSize ZERO = new TerminalSize(0, 0);
-    public static final TerminalSize ONE = new TerminalSize(1, 1);
+public class TerminalSize implements Comparable<TerminalSize> {
+
+    public static final TerminalSize OF_0x0 = new TerminalSize(0, 0);
+    public static final TerminalSize OF_0x1 = new TerminalSize(0, 1);
+    public static final TerminalSize OF_1x0 = new TerminalSize(1, 0);
+    public static final TerminalSize OF_1x1 = new TerminalSize(1, 1);
 
     public final int columns;
     public final int rows;
 
     public static final TerminalSize of(int columns, int rows) {
+        if(columns == 0 && rows == 0) {
+            return OF_0x0;
+        } else if(columns == 0 && rows == 1) {
+            return OF_0x1;
+        } else if(columns == 1 && rows == 0) {
+            return OF_1x0;
+        } else if(columns == 1 && rows == 1) {
+              return OF_1x1;
+        }
         return new TerminalSize(columns, rows);
     }
-
+    public TerminalSize as(int columns, int rows) {
+        return (columns == this.columns && rows == this.rows) ? this : of(columns, rows);
+    }
+    public TerminalSize as(TerminalSize size) {
+        return size == null ? null : as(size.columns, size.rows);
+    }
     /**
      * Creates a new terminal size representation with a given width (columns) and height (rows)
-     * @param columns Width, in number of columns
-     * @param rows Height, in number of columns
+     * @param columns Width as number of columns
+     * @param rows Height as number or rows
      */
     public TerminalSize(int columns, int rows) {
         if (columns < 0 || rows < 0) {
             throw new IllegalArgumentException("TerminalSize dimensions cannot be less than 0: [columns: " + columns + ", rows: " + rows + "]");
         }
-        
         this.columns = columns;
         this.rows = rows;
     }
-
     /**
-     * @return Returns the width of this size representation, in number of columns
+     * @return Width, number of columns, of this size representation
      */
     public int getColumns() {
         return columns;
     }
-
     /**
-     * Creates a new size based on this size, but with a different width
-     * @param columns Width of the new size, in columns
-     * @return New size based on this one, but with a new width
-     */
-    public TerminalSize withColumns(int columns) {
-        if(this.columns == columns) {
-            return this;
-        }
-        if(columns == 0 && this.rows == 0) {
-            return ZERO;
-        }
-        return new TerminalSize(columns, this.rows);
-    }
-
-
-    /**
-     * @return Returns the height of this size representation, in number of rows
+     * @return Height, number of rows, of this size representation
      */
     public int getRows() {
         return rows;
     }
-
     /**
-     * Creates a new size based on this size, but with a different height
-     * @param rows Height of the new size, in rows
-     * @return New size based on this one, but with a new height
+     * Obtain a TerminalSize with the supplied number of columns and this instance's number of rows
+     * @param columns Width as number of columns for the resulting TerminalSize
+     * @return a TerminalSize with the supplied number of columns and this instance's number of rows
+     */
+    public TerminalSize withColumns(int columns) {
+        return as(columns, rows);
+    }
+    /**
+     * Obtain a TerminalSize with this instance's number of columns and the supplied number of rows
+     * @param rows Height as number of rows for the resulting TerminalSize
+     * @return a TerminalSize with this instance's number of columns and the supplied number of rows
      */
     public TerminalSize withRows(int rows) {
-        if(this.rows == rows) {
-            return this;
-        }
-        if(rows == 0 && this.columns == 0) {
-            return ZERO;
-        }
-        return new TerminalSize(this.columns, rows);
+        return as(columns, rows);
     }
-
     /**
-     * Creates a new TerminalSize object representing a size with the same number of rows, but with a column size offset by a
+     * Obtain a TerminalSize with the same number of rows, but with a columns size offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
      * a terminal size <i>delta</i> number of columns wider and for negative numbers shorter.
      * @param delta Column offset
-     * @return New terminal size based off this one but with an applied transformation
+     * @return a TerminalSize based off this one but with an applied transformation
      */
     public TerminalSize withRelativeColumns(int delta) {
-        if(delta == 0) {
-            return this;
-        }
         // Prevent going below 0 (which would throw an exception)
         return withColumns(Math.max(0, columns + delta));
     }
-
     /**
-     * Creates a new TerminalSize object representing a size with the same number of columns, but with a row size offset by a
+     * Obtain a TerminalSize with the same number of columns, but with a row size offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
      * a terminal size <i>delta</i> number of rows longer and for negative numbers shorter.
      * @param delta Row offset
-     * @return New terminal size based off this one but with an applied transformation
+     * @return a TerminalSize based off this one but with an applied transformation
      */
     public TerminalSize withRelativeRows(int delta) {
-        if(delta == 0) {
-            return this;
-        }
         // Prevent going below 0 (which would throw an exception)
         return withRows(Math.max(0, rows + delta));
     }
-
     /**
-     * Creates a new TerminalSize object representing a size based on this object's size but with a delta applied.
+     * Obtain a TerminalSize based on this object's size but with a delta applied.
      * This is the same as calling
      * <code>withRelativeColumns(delta.getColumns()).withRelativeRows(delta.getRows())</code>
      * @param delta Column and row offset
-     * @return New terminal size based off this one but with an applied resize
+     * @return a TerminalSize based off this one but with an applied resize
      */
     public TerminalSize withRelative(TerminalSize delta) {
-        return withRelative(delta.getColumns(), delta.getRows());
+        return plus(delta);
     }
-
     /**
-     * Creates a new TerminalSize object representing a size based on this object's size but with a delta applied.
+     * Obtain a TerminalSize based on this object's size but with a delta applied.
      * This is the same as calling
      * <code>withRelativeColumns(deltaColumns).withRelativeRows(deltaRows)</code>
-     * @param deltaColumns How many extra columns the new TerminalSize will have (negative values are allowed)
-     * @param deltaRows How many extra rows the new TerminalSize will have (negative values are allowed)
+     * @param deltaColumns How many extra columns the new TerminalSize will have (negative delta values are allowed)
+     * @param deltaRows How many extra rows the new TerminalSize will have (negative delta values are allowed)
      * @return New terminal size based off this one but with an applied resize
      */
     public TerminalSize withRelative(int deltaColumns, int deltaRows) {
-        return withRelativeRows(deltaRows).withRelativeColumns(deltaColumns);
+        return plus(deltaColumns, deltaRows);
     }
-
     /**
-     * Takes a different TerminalSize and returns a new TerminalSize that has the largest dimensions of the two,
-     * measured separately. So calling 3x5 on a 5x3 will return 5x5.
-     * @param other Other TerminalSize to compare with
-     * @return TerminalSize that combines the maximum width between the two and the maximum height
+     * Obtain a TerminalSize having the max columns and max rows of this instance and the supplied one.
+     * Example: calling 3x5 on a 5x3 will return 5x5.
+     * @param other TerminalSize to compare with
+     * @return a TerminalSize that combines the maximum width and maximum height between the two
      */
     public TerminalSize max(TerminalSize other) {
-        return withColumns(Math.max(columns, other.columns))
-                .withRows(Math.max(rows, other.rows));
+        return as(Math.max(columns, other.columns), Math.max(rows, other.rows));
     }
-
     /**
-     * Takes a different TerminalSize and returns a new TerminalSize that has the smallest dimensions of the two,
-     * measured separately. So calling 3x5 on a 5x3 will return 3x3.
-     * @param other Other TerminalSize to compare with
-     * @return TerminalSize that combines the minimum width between the two and the minimum height
+     * Obtain a TerminalSize having the min columns and min rows of this instance and the supplied one.
+     * Example: calling 3x5 on a 5x3 will return 3x3.
+     * @param other TerminalSize to compare with
+     * @return a TerminalSize that combines the minimum width and minimum height between the two
      */
     public TerminalSize min(TerminalSize other) {
-        return withColumns(Math.min(columns, other.columns))
-                .withRows(Math.min(rows, other.rows));
+        return as(Math.min(columns, other.columns), Math.min(rows, other.rows));
     }
 
     public TerminalSize plus(TerminalSize other) {
@@ -182,16 +167,16 @@ public class TerminalSize {
         return divide(denominator.columns, denominator.rows);
     }
     public TerminalSize plus(int columns, int rows) {
-        return of(this.columns + columns, this.rows + rows);
+        return as(this.columns + columns, this.rows + rows);
     }
     public TerminalSize minus(int columns, int rows) {
-        return of(this.columns - columns, this.rows - rows);
+        return as(this.columns - columns, this.rows - rows);
     }
     public TerminalSize multiply(int columns, int rows) {
-        return of(this.columns * columns, this.rows * rows);
+        return as(this.columns * columns, this.rows * rows);
     }
     public TerminalSize divide(int columnsDenominator, int rowsDenominator) {
-        return of(columns / columnsDenominator, rows / rowsDenominator);
+        return as(columns / columnsDenominator, rows / rowsDenominator);
     }
     public TerminalSize plus(int amount)        { return plus(amount, amount); }
     public TerminalSize minus(int amount)       { return minus(amount, amount); }
@@ -206,10 +191,7 @@ public class TerminalSize {
      * @return Itself if this size equals the size passed in, otherwise the size passed in
      */
     public TerminalSize with(TerminalSize size) {
-        if(equals(size)) {
-            return this;
-        }
-        return size;
+        return as(size);
     }
 
     /**
@@ -221,6 +203,15 @@ public class TerminalSize {
     public int getDimension(int d) {
         return d == 0 ? getColumns() : getRows();
     }
+    
+    @Override
+    public int compareTo(TerminalSize other) {
+        return Integer.compare(columns * rows, other.columns * other.rows);
+    }
+
+    public boolean equals(int columns, int rows) {
+        return this.columns == columns && this.rows == rows;
+    }
 
     @Override
     public String toString() {
@@ -229,16 +220,11 @@ public class TerminalSize {
 
     @Override
     public boolean equals(Object obj) {
-        if(this == obj) {
-            return true;
-        }
-        if (!(obj instanceof TerminalSize)) {
-            return false;
-        }
-
-        TerminalSize other = (TerminalSize) obj;
-        return columns == other.columns
-                && rows == other.rows;
+        return obj != null
+            && obj.getClass() == getClass()
+            && ((TerminalSize) obj).columns == columns
+            && ((TerminalSize) obj).rows == rows
+            ;
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/TerminalSize.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalSize.java
@@ -31,6 +31,7 @@ public class TerminalSize implements Comparable<TerminalSize> {
     public static final TerminalSize OF_1x0 = new TerminalSize(1, 0);
     public static final TerminalSize OF_1x1 = new TerminalSize(1, 1);
 
+    // one of the benefits of immutable: ease of usage
     public final int columns;
     public final int rows;
 
@@ -65,20 +66,20 @@ public class TerminalSize implements Comparable<TerminalSize> {
         this.rows = rows;
     }
     /**
-     * @return Width, number of columns, of this size representation
+     * @return Width, the number of columns of this TerminalSize
      */
     public int getColumns() {
         return columns;
     }
     /**
-     * @return Height, number of rows, of this size representation
+     * @return Height, the number of rows of this TerminalSize
      */
     public int getRows() {
         return rows;
     }
     /**
      * Obtain a TerminalSize with the supplied number of columns and this instance's number of rows
-     * @param columns Width as number of columns for the resulting TerminalSize
+     * @param columns, the number of columns, or Width, of the resulting TerminalSize
      * @return a TerminalSize with the supplied number of columns and this instance's number of rows
      */
     public TerminalSize withColumns(int columns) {
@@ -86,7 +87,7 @@ public class TerminalSize implements Comparable<TerminalSize> {
     }
     /**
      * Obtain a TerminalSize with this instance's number of columns and the supplied number of rows
-     * @param rows Height as number of rows for the resulting TerminalSize
+     * @param rows, the number or rows, or Height, of the resulting TerminalSize
      * @return a TerminalSize with this instance's number of columns and the supplied number of rows
      */
     public TerminalSize withRows(int rows) {
@@ -95,9 +96,9 @@ public class TerminalSize implements Comparable<TerminalSize> {
     /**
      * Obtain a TerminalSize with the same number of rows, but with a columns size offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
-     * a terminal size <i>delta</i> number of columns wider and for negative numbers shorter.
+     * a TerminalSize <i>delta</i> number of columns wider and for negative numbers shorter.
      * @param delta Column offset
-     * @return a TerminalSize based off this one but with an applied transformation
+     * @return a TerminalSize based off this one but with an applied translation
      */
     public TerminalSize withRelativeColumns(int delta) {
         // Prevent going below 0 (which would throw an exception)
@@ -106,9 +107,9 @@ public class TerminalSize implements Comparable<TerminalSize> {
     /**
      * Obtain a TerminalSize with the same number of columns, but with a row size offset by a
      * supplied value. Calling this method with delta 0 will return this, calling it with a positive delta will return
-     * a terminal size <i>delta</i> number of rows longer and for negative numbers shorter.
+     * a TerminalSize <i>delta</i> number of rows longer and for negative numbers shorter.
      * @param delta Row offset
-     * @return a TerminalSize based off this one but with an applied transformation
+     * @return a TerminalSize resulting from translating this instance by the supplied delta rows
      */
     public TerminalSize withRelativeRows(int delta) {
         // Prevent going below 0 (which would throw an exception)
@@ -128,9 +129,9 @@ public class TerminalSize implements Comparable<TerminalSize> {
      * Obtain a TerminalSize based on this object's size but with a delta applied.
      * This is the same as calling
      * <code>withRelativeColumns(deltaColumns).withRelativeRows(deltaRows)</code>
-     * @param deltaColumns How many extra columns the new TerminalSize will have (negative delta values are allowed)
-     * @param deltaRows How many extra rows the new TerminalSize will have (negative delta values are allowed)
-     * @return New terminal size based off this one but with an applied resize
+     * @param deltaColumns How many extra columns the resulting TerminalSize will have (negative delta values are allowed)
+     * @param deltaRows How many extra rows the resulting TerminalSize will have (negative delta values are allowed)
+     * @return a TerminalSize based off this one but with an applied resize
      */
     public TerminalSize withRelative(int deltaColumns, int deltaRows) {
         return plus(deltaColumns, deltaRows);

--- a/src/main/java/com/googlecode/lanterna/TerminalSize.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalSize.java
@@ -28,8 +28,12 @@ public class TerminalSize {
     public static final TerminalSize ZERO = new TerminalSize(0, 0);
     public static final TerminalSize ONE = new TerminalSize(1, 1);
 
-    private final int columns;
-    private final int rows;
+    public final int columns;
+    public final int rows;
+
+    public static final TerminalSize of(int columns, int rows) {
+        return new TerminalSize(columns, rows);
+    }
 
     /**
      * Creates a new terminal size representation with a given width (columns) and height (rows)
@@ -165,6 +169,35 @@ public class TerminalSize {
                 .withRows(Math.min(rows, other.rows));
     }
 
+    public TerminalSize plus(TerminalSize other) {
+        return plus(other.columns, other.rows);
+    }
+    public TerminalSize minus(TerminalSize other) {
+        return minus(other.columns, other.rows);
+    }
+    public TerminalSize multiply(TerminalSize other) {
+        return multiply(other.columns, other.rows);
+    }
+    public TerminalSize divide(TerminalSize denominator) {
+        return divide(denominator.columns, denominator.rows);
+    }
+    public TerminalSize plus(int columns, int rows) {
+        return of(this.columns + columns, this.rows + rows);
+    }
+    public TerminalSize minus(int columns, int rows) {
+        return of(this.columns - columns, this.rows - rows);
+    }
+    public TerminalSize multiply(int columns, int rows) {
+        return of(this.columns * columns, this.rows * rows);
+    }
+    public TerminalSize divide(int columnsDenominator, int rowsDenominator) {
+        return of(columns / columnsDenominator, rows / rowsDenominator);
+    }
+    public TerminalSize plus(int amount)        { return plus(amount, amount); }
+    public TerminalSize minus(int amount)       { return minus(amount, amount); }
+    public TerminalSize multiply(int amount)    { return multiply(amount, amount); }
+    public TerminalSize divide(int denominator) { return divide(denominator, denominator); }
+
     /**
      * Returns itself if it is equal to the supplied size, otherwise the supplied size. You can use this if you have a
      * size field which is frequently recalculated but often resolves to the same size; it will keep the same object
@@ -177,6 +210,16 @@ public class TerminalSize {
             return this;
         }
         return size;
+    }
+
+    /**
+     * x dimension, when d is zero
+     * y dimension, when d is not zero
+     *
+     * @return either getColumns() for x dimension or getRows() for y dimension
+    */
+    public int getDimension(int d) {
+        return d == 0 ? getColumns() : getRows();
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/graphics/AbstractTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/AbstractTextGraphics.java
@@ -120,7 +120,7 @@ public abstract class AbstractTextGraphics implements TextGraphics {
 
     @Override
     public TextGraphics fill(char c) {
-        fillRectangle(TerminalPosition.TOP_LEFT_CORNER, getSize(), c);
+        fillRectangle(TerminalPosition.OF_0x0, getSize(), c);
         return this;
     }
 
@@ -158,7 +158,7 @@ public abstract class AbstractTextGraphics implements TextGraphics {
 
     @Override
     public TextGraphics drawLine(int fromX, int fromY, int toX, int toY, TextCharacter character) {
-        return drawLine(new TerminalPosition(fromX, fromY), new TerminalPosition(toX, toY), character);
+        return drawLine(TerminalPosition.of(fromX, fromY), TerminalPosition.of(toX, toY), character);
     }
 
     @Override
@@ -207,7 +207,7 @@ public abstract class AbstractTextGraphics implements TextGraphics {
 
     @Override
     public TextGraphics drawImage(TerminalPosition topLeft, TextImage image) {
-        return drawImage(topLeft, image, TerminalPosition.TOP_LEFT_CORNER, image.getSize());
+        return drawImage(topLeft, image, TerminalPosition.OF_0x0, image.getSize());
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
@@ -42,7 +42,7 @@ public class BasicTextImage implements TextImage {
      * @param rows Size of the image in number of rows
      */
     public BasicTextImage(int columns, int rows) {
-        this(new TerminalSize(columns, rows));
+        this(TerminalSize.of(columns, rows));
     }
     
     /**

--- a/src/main/java/com/googlecode/lanterna/graphics/DefaultShapeRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/DefaultShapeRenderer.java
@@ -162,20 +162,20 @@ class DefaultShapeRenderer implements ShapeRenderer {
         startY =        points[0].getRow();
         if (dx1 > dx2) {
             for (; startY <= points[1].getRow(); startY++, startX += dx2, endX += dx1) {
-                drawLine(new TerminalPosition((int)startX, (int)startY), new TerminalPosition((int)endX, (int)startY), character);
+                drawLine(TerminalPosition.of((int)startX, (int)startY), TerminalPosition.of((int)endX, (int)startY), character);
             }
             endX = points[1].getColumn();
             for (; startY <= points[2].getRow(); startY++, startX += dx2, endX += dx3) {
-                drawLine(new TerminalPosition((int)startX, (int)startY), new TerminalPosition((int)endX, (int)startY), character);
+                drawLine(TerminalPosition.of((int)startX, (int)startY), TerminalPosition.of((int)endX, (int)startY), character);
             }
         } else {
             for (; startY <= points[1].getRow(); startY++, startX += dx1, endX += dx2) {
-                drawLine(new TerminalPosition((int)startX, (int)startY), new TerminalPosition((int)endX, (int)startY), character);
+                drawLine(TerminalPosition.of((int)startX, (int)startY), TerminalPosition.of((int)endX, (int)startY), character);
             }
             startX = points[1].getColumn();
             startY = points[1].getRow();
             for (; startY <= points[2].getRow(); startY++, startX += dx3, endX += dx2) {
-                drawLine(new TerminalPosition((int)startX, (int)startY), new TerminalPosition((int)endX, (int)startY), character);
+                drawLine(TerminalPosition.of((int)startX, (int)startY), TerminalPosition.of((int)endX, (int)startY), character);
             }
         }
     }

--- a/src/main/java/com/googlecode/lanterna/graphics/TextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/TextGraphics.java
@@ -54,7 +54,7 @@ public interface TextGraphics extends StyleSet<TextGraphics> {
     /**
      * Creates a new TextGraphics of the same type as this one, using the same underlying subsystem. Using this method,
      * you need to specify a section of the current TextGraphics valid area that this new TextGraphic shall be
-     * restricted to. If you call <code>newTextGraphics(TerminalPosition.TOP_LEFT_CORNER, textGraphics.getSize())</code>
+     * restricted to. If you call <code>newTextGraphics(TerminalPosition.of(0, 0), textGraphics.getSize())</code>
      * then the resulting object will be identical to this one, but having a separated state for colors, position and
      * modifiers.
      * @param topLeftCorner Position of this TextGraphics's writable area that is to become the top-left corner (0x0) of
@@ -281,7 +281,7 @@ public interface TextGraphics extends StyleSet<TextGraphics> {
     /**
      * Takes a TextImage and draws it on the surface this TextGraphics is targeting, given the coordinates on the target
      * that is specifying where the top-left corner of the image should be drawn. This is equivalent of calling
-     * {@code drawImage(topLeft, image, TerminalPosition.TOP_LEFT_CORNER, image.getSize()}.
+     * {@code drawImage(topLeft, image, TerminalPosition.of(0, 0), image.getSize()}.
      * @param topLeft Position of the top-left corner of the image on the target
      * @param image Image to draw
      * @return Itself

--- a/src/main/java/com/googlecode/lanterna/graphics/TextGraphicsWriter.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/TextGraphicsWriter.java
@@ -24,7 +24,7 @@ public class TextGraphicsWriter implements StyleSet<TextGraphicsWriter> {
     public TextGraphicsWriter(TextGraphics backend) {
         this.backend = backend;
         setStyleFrom( backend );
-        cursorPosition = new TerminalPosition(0, 0);
+        cursorPosition = TerminalPosition.OF_0x0;
     }
 
     public TextGraphicsWriter putString(String string) {

--- a/src/main/java/com/googlecode/lanterna/gui2/AbsoluteLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbsoluteLayout.java
@@ -34,8 +34,7 @@ public class AbsoluteLayout implements LayoutManager {
     public TerminalSize getPreferredSize(List<Component> components) {
         TerminalSize size = TerminalSize.OF_0x0;
         for(Component component: components) {
-            size = size.max(
-                    new TerminalSize(
+            size = size.max(TerminalSize.of(
                             component.getPosition().getColumn() + component.getSize().getColumns(),
                             component.getPosition().getRow() + component.getSize().getRows()));
                     

--- a/src/main/java/com/googlecode/lanterna/gui2/AbsoluteLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbsoluteLayout.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class AbsoluteLayout implements LayoutManager {
     @Override
     public TerminalSize getPreferredSize(List<Component> components) {
-        TerminalSize size = TerminalSize.ZERO;
+        TerminalSize size = TerminalSize.OF_0x0;
         for(Component component: components) {
             size = size.max(
                     new TerminalSize(

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -461,9 +461,9 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
                 public void drawComponent(TextGUIGraphics graphics, Container component) {
                     if (!(menuBar instanceof EmptyMenuBar)) {
                         int menuBarHeight = menuBar.getPreferredSize().getRows();
-                        TextGUIGraphics menuGraphics = graphics.newTextGraphics(TerminalPosition.TOP_LEFT_CORNER, graphics.getSize().withRows(menuBarHeight));
+                        TextGUIGraphics menuGraphics = graphics.newTextGraphics(TerminalPosition.OF_0x0, graphics.getSize().withRows(menuBarHeight));
                         menuBar.draw(menuGraphics);
-                        graphics = graphics.newTextGraphics(TerminalPosition.TOP_LEFT_CORNER.withRelativeRow(menuBarHeight), graphics.getSize().withRelativeRows(-menuBarHeight));
+                        graphics = graphics.newTextGraphics(TerminalPosition.of(0, menuBarHeight), graphics.getSize().withRelativeRows(-menuBarHeight));
                     }
 
                     Component subComponent = getComponent();

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -452,7 +452,7 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
                 public TerminalSize getPreferredSize(Container component) {
                     Component subComponent = getComponent();
                     if(subComponent == null) {
-                        return TerminalSize.ZERO;
+                        return TerminalSize.OF_0x0;
                     }
                     return subComponent.getPreferredSize();
                 }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -50,7 +50,7 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
     protected AbstractBasePane() {
         this.contentHolder = new ContentHolder();
         this.listeners = new CopyOnWriteArrayList<>();
-        this.interactableLookupMap = new InteractableLookupMap(new TerminalSize(80, 25));
+        this.interactableLookupMap = new InteractableLookupMap(TerminalSize.of(80, 25));
         this.invalid = false;
         this.strictFocusChange = false;
         this.enableDirectionBasedMovements = true;

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBorder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBorder.java
@@ -32,7 +32,7 @@ public abstract class AbstractBorder extends AbstractComposite<Border> implement
     public void setComponent(Component component) {
         super.setComponent(component);
         if(component != null) {
-            component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+            component.setPosition(TerminalPosition.OF_0x0);
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
@@ -77,7 +77,7 @@ public abstract class AbstractComponent<T extends Component> implements Componen
      */
     public AbstractComponent() {
         size = TerminalSize.ZERO;
-        position = TerminalPosition.TOP_LEFT_CORNER;
+        position = TerminalPosition.OF_0x0;
         explicitPreferredSize = null;
         layoutData = null;
         visible = true;
@@ -233,7 +233,7 @@ public abstract class AbstractComponent<T extends Component> implements Componen
     
     @Override
     public TerminalPosition getGlobalPosition() {
-        return toGlobal(TerminalPosition.TOP_LEFT_CORNER);
+        return toGlobal(TerminalPosition.OF_0x0);
     }
     
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
@@ -76,7 +76,7 @@ public abstract class AbstractComponent<T extends Component> implements Componen
      * Default constructor
      */
     public AbstractComponent() {
-        size = TerminalSize.ZERO;
+        size = TerminalSize.OF_0x0;
         position = TerminalPosition.OF_0x0;
         explicitPreferredSize = null;
         layoutData = null;

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
@@ -60,9 +60,9 @@ public abstract class AbstractComposite<T extends Container> extends AbstractCom
             if (getBasePane() != null) {
                 MenuBar menuBar = getBasePane().getMenuBar();
                 if (menuBar == null || menuBar.isEmptyMenuBar()) {
-                    component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+                    component.setPosition(TerminalPosition.OF_0x0);
                 } else {
-                    component.setPosition(TerminalPosition.TOP_LEFT_CORNER.withRelativeRow(1));
+                    component.setPosition(TerminalPosition.OF_0x1);
                 }
             }
             invalidate();

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
@@ -39,7 +39,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
     private final List<V> items;
     private int selectedIndex;
     private ListItemRenderer<V,T> listItemRenderer;
-    protected TerminalPosition scrollOffset = new TerminalPosition(0, 0);
+    protected TerminalPosition scrollOffset = TerminalPosition.OF_0x0;
     
     /**
      * This constructor sets up the component so it has no preferred size but will ask to be as big as the list is. If
@@ -403,7 +403,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
             if(columnAccordingToRenderer == -1) {
                 return null;
             }
-            return new TerminalPosition(columnAccordingToRenderer, selectedIndex - scrollTopIndex);
+            return TerminalPosition.of(columnAccordingToRenderer, selectedIndex - scrollTopIndex);
         }
 
         @Override
@@ -445,7 +445,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                 scrollTopIndex = items.size() - componentHeight;
             }
             
-            listBox.scrollOffset = new TerminalPosition(0, -scrollTopIndex);
+            listBox.scrollOffset = TerminalPosition.of(0, -scrollTopIndex);
 
             graphics.applyThemeStyle(themeDefinition.getNormal());
             graphics.fill(' ');
@@ -456,7 +456,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                     break;
                 }
                 listItemRenderer.drawItem(
-                        graphics.newTextGraphics(new TerminalPosition(0, i - scrollTopIndex), itemSize),
+                        graphics.newTextGraphics(TerminalPosition.of(0, i - scrollTopIndex), itemSize),
                         listBox,
                         i,
                         items.get(i),
@@ -471,7 +471,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                 verticalScrollBar.setScrollMaximum(items.size());
                 verticalScrollBar.setScrollPosition(scrollTopIndex);
                 verticalScrollBar.draw(graphics.newTextGraphics(
-                        new TerminalPosition(graphics.getSize().getColumns() - 1, 0),
+                        TerminalPosition.of(graphics.getSize().getColumns() - 1, 0),
                         new TerminalSize(1, graphics.getSize().getRows())));
             }
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
@@ -417,7 +417,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                     maxWidth = stringLengthInColumns;
                 }
             }
-            return new TerminalSize(maxWidth + 1, listBox.getItemCount());
+            return TerminalSize.of(maxWidth + 1, listBox.getItemCount());
         }
 
         @Override
@@ -472,7 +472,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                 verticalScrollBar.setScrollPosition(scrollTopIndex);
                 verticalScrollBar.draw(graphics.newTextGraphics(
                         TerminalPosition.of(graphics.getSize().getColumns() - 1, 0),
-                        new TerminalSize(1, graphics.getSize().getRows())));
+                        TerminalSize.of(1, graphics.getSize().getRows())));
             }
         }
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
@@ -60,7 +60,7 @@ public abstract class AbstractWindow extends AbstractBasePane<Window> implements
         this.title = title;
         this.textGUI = null;
         this.visible = true;
-        this.contentOffset = TerminalPosition.TOP_LEFT_CORNER;
+        this.contentOffset = TerminalPosition.OF_0x0;
         this.lastKnownPosition = null;
         this.lastKnownSize = null;
         this.lastKnownDecoratedSize = null;

--- a/src/main/java/com/googlecode/lanterna/gui2/AnimatedLabel.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AnimatedLabel.java
@@ -68,7 +68,7 @@ public class AnimatedLabel extends Label {
         super(firstFrameText);
         frames = new ArrayList<>();
         currentFrame = 0;
-        combinedMaximumPreferredSize = TerminalSize.ZERO;
+        combinedMaximumPreferredSize = TerminalSize.OF_0x0;
 
         String[] lines = splitIntoMultipleLines(firstFrameText);
         frames.add(lines);

--- a/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
@@ -98,7 +98,7 @@ public class BorderLayout implements LayoutManager {
                     Math.max(
                         layout.containsKey(Location.TOP) ? layout.get(Location.TOP).getPreferredSize().getColumns() : 0,
                         layout.containsKey(Location.BOTTOM) ? layout.get(Location.BOTTOM).getPreferredSize().getColumns() : 0));
-        return new TerminalSize(preferredWidth, preferredHeight);
+        return TerminalSize.of(preferredWidth, preferredHeight);
     }
 
     @Override
@@ -116,7 +116,7 @@ public class BorderLayout implements LayoutManager {
             Component topComponent = layout.get(Location.TOP);
             topComponentHeight = Math.min(topComponent.getPreferredSize().getRows(), availableVerticalSpace);
             topComponent.setPosition(TerminalPosition.OF_0x0);
-            topComponent.setSize(new TerminalSize(availableHorizontalSpace, topComponentHeight));
+            topComponent.setSize(TerminalSize.of(availableHorizontalSpace, topComponentHeight));
             availableVerticalSpace -= topComponentHeight;
         }
 
@@ -125,7 +125,7 @@ public class BorderLayout implements LayoutManager {
             Component bottomComponent = layout.get(Location.BOTTOM);
             int bottomComponentHeight = Math.min(bottomComponent.getPreferredSize().getRows(), availableVerticalSpace);
             bottomComponent.setPosition(TerminalPosition.of(0, area.getRows() - bottomComponentHeight));
-            bottomComponent.setSize(new TerminalSize(availableHorizontalSpace, bottomComponentHeight));
+            bottomComponent.setSize(TerminalSize.of(availableHorizontalSpace, bottomComponentHeight));
             availableVerticalSpace -= bottomComponentHeight;
         }
 
@@ -134,20 +134,20 @@ public class BorderLayout implements LayoutManager {
             Component leftComponent = layout.get(Location.LEFT);
             leftComponentWidth = Math.min(leftComponent.getPreferredSize().getColumns(), availableHorizontalSpace);
             leftComponent.setPosition(TerminalPosition.of(0, topComponentHeight));
-            leftComponent.setSize(new TerminalSize(leftComponentWidth, availableVerticalSpace));
+            leftComponent.setSize(TerminalSize.of(leftComponentWidth, availableVerticalSpace));
             availableHorizontalSpace -= leftComponentWidth;
         }
         if(layout.containsKey(Location.RIGHT)) {
             Component rightComponent = layout.get(Location.RIGHT);
             int rightComponentWidth = Math.min(rightComponent.getPreferredSize().getColumns(), availableHorizontalSpace);
             rightComponent.setPosition(TerminalPosition.of(area.getColumns() - rightComponentWidth, topComponentHeight));
-            rightComponent.setSize(new TerminalSize(rightComponentWidth, availableVerticalSpace));
+            rightComponent.setSize(TerminalSize.of(rightComponentWidth, availableVerticalSpace));
             availableHorizontalSpace -= rightComponentWidth;
         }
         if(layout.containsKey(Location.CENTER)) {
             Component centerComponent = layout.get(Location.CENTER);
             centerComponent.setPosition(TerminalPosition.of(leftComponentWidth, topComponentHeight));
-            centerComponent.setSize(new TerminalSize(availableHorizontalSpace, availableVerticalSpace));
+            centerComponent.setSize(TerminalSize.of(availableHorizontalSpace, availableVerticalSpace));
         }
         
         //Set the remaining components to 0x0

--- a/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
@@ -115,7 +115,7 @@ public class BorderLayout implements LayoutManager {
         if(layout.containsKey(Location.TOP)) {
             Component topComponent = layout.get(Location.TOP);
             topComponentHeight = Math.min(topComponent.getPreferredSize().getRows(), availableVerticalSpace);
-            topComponent.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+            topComponent.setPosition(TerminalPosition.OF_0x0);
             topComponent.setSize(new TerminalSize(availableHorizontalSpace, topComponentHeight));
             availableVerticalSpace -= topComponentHeight;
         }
@@ -124,7 +124,7 @@ public class BorderLayout implements LayoutManager {
         if(layout.containsKey(Location.BOTTOM)) {
             Component bottomComponent = layout.get(Location.BOTTOM);
             int bottomComponentHeight = Math.min(bottomComponent.getPreferredSize().getRows(), availableVerticalSpace);
-            bottomComponent.setPosition(new TerminalPosition(0, area.getRows() - bottomComponentHeight));
+            bottomComponent.setPosition(TerminalPosition.of(0, area.getRows() - bottomComponentHeight));
             bottomComponent.setSize(new TerminalSize(availableHorizontalSpace, bottomComponentHeight));
             availableVerticalSpace -= bottomComponentHeight;
         }
@@ -133,27 +133,27 @@ public class BorderLayout implements LayoutManager {
         if(layout.containsKey(Location.LEFT)) {
             Component leftComponent = layout.get(Location.LEFT);
             leftComponentWidth = Math.min(leftComponent.getPreferredSize().getColumns(), availableHorizontalSpace);
-            leftComponent.setPosition(new TerminalPosition(0, topComponentHeight));
+            leftComponent.setPosition(TerminalPosition.of(0, topComponentHeight));
             leftComponent.setSize(new TerminalSize(leftComponentWidth, availableVerticalSpace));
             availableHorizontalSpace -= leftComponentWidth;
         }
         if(layout.containsKey(Location.RIGHT)) {
             Component rightComponent = layout.get(Location.RIGHT);
             int rightComponentWidth = Math.min(rightComponent.getPreferredSize().getColumns(), availableHorizontalSpace);
-            rightComponent.setPosition(new TerminalPosition(area.getColumns() - rightComponentWidth, topComponentHeight));
+            rightComponent.setPosition(TerminalPosition.of(area.getColumns() - rightComponentWidth, topComponentHeight));
             rightComponent.setSize(new TerminalSize(rightComponentWidth, availableVerticalSpace));
             availableHorizontalSpace -= rightComponentWidth;
         }
         if(layout.containsKey(Location.CENTER)) {
             Component centerComponent = layout.get(Location.CENTER);
-            centerComponent.setPosition(new TerminalPosition(leftComponentWidth, topComponentHeight));
+            centerComponent.setPosition(TerminalPosition.of(leftComponentWidth, topComponentHeight));
             centerComponent.setSize(new TerminalSize(availableHorizontalSpace, availableVerticalSpace));
         }
         
         //Set the remaining components to 0x0
         for(Component component: components) {
             if(component.isVisible() && !layout.containsValue(component)) {
-                component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+                component.setPosition(TerminalPosition.OF_0x0);
                 component.setSize(TerminalSize.ZERO);
             }
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/BorderLayout.java
@@ -154,7 +154,7 @@ public class BorderLayout implements LayoutManager {
         for(Component component: components) {
             if(component.isVisible() && !layout.containsValue(component)) {
                 component.setPosition(TerminalPosition.OF_0x0);
-                component.setSize(TerminalSize.ZERO);
+                component.setSize(TerminalSize.OF_0x0);
             }
         }
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/Borders.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Borders.java
@@ -197,7 +197,7 @@ public class Borders {
 
         @Override
         public TerminalPosition getWrappedComponentTopLeftOffset() {
-            return TerminalPosition.OFFSET_1x1;
+            return TerminalPosition.OF_1x1;
         }
 
         @Override
@@ -234,11 +234,11 @@ public class Borders {
             }
             graphics.setCharacter(0, drawableArea.getRows() - 1, bottomLeftCorner);
             if(drawableArea.getRows() > 2) {
-                graphics.drawLine(new TerminalPosition(0, drawableArea.getRows() - 2), new TerminalPosition(0, 1), verticalLine);
+                graphics.drawLine(TerminalPosition.of(0, drawableArea.getRows() - 2), TerminalPosition.OF_0x1, verticalLine);
             }
             graphics.setCharacter(0, 0, topLeftCorner);
             if(drawableArea.getColumns() > 2) {
-                graphics.drawLine(new TerminalPosition(1, 0), new TerminalPosition(drawableArea.getColumns() - 2, 0), horizontalLine);
+                graphics.drawLine(TerminalPosition.OF_1x0, TerminalPosition.of(drawableArea.getColumns() - 2, 0), horizontalLine);
             }
 
             if(borderStyle == BorderStyle.ReverseBevel) {
@@ -249,14 +249,14 @@ public class Borders {
             }
             graphics.setCharacter(drawableArea.getColumns() - 1, 0, topRightCorner);
             if(drawableArea.getRows() > 2) {
-                graphics.drawLine(new TerminalPosition(drawableArea.getColumns() - 1, 1),
-                        new TerminalPosition(drawableArea.getColumns() - 1, drawableArea.getRows() - 2),
+                graphics.drawLine(TerminalPosition.of(drawableArea.getColumns() - 1, 1),
+                        TerminalPosition.of(drawableArea.getColumns() - 1, drawableArea.getRows() - 2),
                         verticalLine);
             }
             graphics.setCharacter(drawableArea.getColumns() - 1, drawableArea.getRows() - 1, bottomRightCorner);
             if(drawableArea.getColumns() > 2) {
-                graphics.drawLine(new TerminalPosition(1, drawableArea.getRows() - 1),
-                        new TerminalPosition(drawableArea.getColumns() - 2, drawableArea.getRows() - 1),
+                graphics.drawLine(TerminalPosition.of(1, drawableArea.getRows() - 1),
+                        TerminalPosition.of(drawableArea.getColumns() - 2, drawableArea.getRows() - 1),
                         horizontalLine);
             }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/Borders.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Borders.java
@@ -192,7 +192,7 @@ public class Borders {
             }
             preferredSize = preferredSize.withRelativeColumns(2).withRelativeRows(2);
             String borderTitle = border.getTitle();
-            return preferredSize.max(new TerminalSize((borderTitle.isEmpty() ? 2 : TerminalTextUtils.getColumnWidth(borderTitle) + 4), 2));
+            return preferredSize.max(TerminalSize.of((borderTitle.isEmpty() ? 2 : TerminalTextUtils.getColumnWidth(borderTitle) + 4), 2));
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/Borders.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Borders.java
@@ -186,7 +186,7 @@ public class Borders {
             Component wrappedComponent = border.getComponent();
             TerminalSize preferredSize;
             if (wrappedComponent == null) {
-                preferredSize = TerminalSize.ZERO;
+                preferredSize = TerminalSize.OF_0x0;
             } else {
                 preferredSize = wrappedComponent.getPreferredSize();
             }

--- a/src/main/java/com/googlecode/lanterna/gui2/Button.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Button.java
@@ -160,7 +160,7 @@ public class Button extends AbstractInteractableComponent<Button> {
         @Override
         public TerminalPosition getCursorLocation(Button button) {
             if(button.getThemeDefinition().isCursorVisible()) {
-                return new TerminalPosition(1 + getLabelShift(button, button.getSize()), 0);
+                return TerminalPosition.of(1 + getLabelShift(button, button.getSize()), 0);
             }
             else {
                 return null;

--- a/src/main/java/com/googlecode/lanterna/gui2/Button.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Button.java
@@ -169,7 +169,7 @@ public class Button extends AbstractInteractableComponent<Button> {
 
         @Override
         public TerminalSize getPreferredSize(Button button) {
-            return new TerminalSize(Math.max(8, TerminalTextUtils.getColumnWidth(button.getLabel()) + 2), 1);
+            return TerminalSize.of(Math.max(8, TerminalTextUtils.getColumnWidth(button.getLabel()) + 2), 1);
         }
 
         @Override
@@ -231,7 +231,7 @@ public class Button extends AbstractInteractableComponent<Button> {
 
         @Override
         public TerminalSize getPreferredSize(Button component) {
-            return new TerminalSize(TerminalTextUtils.getColumnWidth(component.getLabel()), 1);
+            return TerminalSize.of(TerminalTextUtils.getColumnWidth(component.getLabel()), 1);
         }
 
         @Override
@@ -262,7 +262,7 @@ public class Button extends AbstractInteractableComponent<Button> {
 
         @Override
         public TerminalSize getPreferredSize(Button component) {
-            return new TerminalSize(TerminalTextUtils.getColumnWidth(component.getLabel()) + 5, 4);
+            return TerminalSize.of(TerminalTextUtils.getColumnWidth(component.getLabel()) + 5, 4);
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
@@ -192,7 +192,7 @@ public class CheckBox extends AbstractInteractableComponent<CheckBox> {
             if(!component.label.isEmpty()) {
                 width += 1 + TerminalTextUtils.getColumnWidth(component.label);
             }
-            return new TerminalSize(width, 1);
+            return TerminalSize.of(width, 1);
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
@@ -175,7 +175,7 @@ public class CheckBox extends AbstractInteractableComponent<CheckBox> {
      * of a "[ ]" block which will contain a "X" inside it if the check box has toggle status on
      */
     public static class DefaultCheckBoxRenderer extends CheckBoxRenderer {
-        private static final TerminalPosition CURSOR_LOCATION = new TerminalPosition(1, 0);
+        private static final TerminalPosition CURSOR_LOCATION = TerminalPosition.OF_1x0;
         @Override
         public TerminalPosition getCursorLocation(CheckBox component) {
             if(component.getThemeDefinition().isCursorVisible()) {

--- a/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
@@ -648,7 +648,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
             synchronized(comboBox) {
                 for(int i = 0; i < comboBox.getItemCount(); i++) {
                     V item = comboBox.getItem(i);
-                    size = size.max(new TerminalSize(TerminalTextUtils.getColumnWidth(item.toString()) + 2 + 1, 1));   // +1 to add a single column of space
+                    size = size.max(TerminalSize.of(TerminalTextUtils.getColumnWidth(item.toString()) + 2 + 1, 1));   // +1 to add a single column of space
                 }
             }
             return size;

--- a/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
@@ -642,7 +642,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
 
         @Override
         public TerminalSize getPreferredSize(final ComboBox<V> comboBox) {
-            TerminalSize size = TerminalSize.ONE.withColumns(
+            TerminalSize size = TerminalSize.OF_1x1.withColumns(
                     (comboBox.getItemCount() == 0 ? TerminalTextUtils.getColumnWidth(comboBox.getText()) : 0) + 2);
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized(comboBox) {

--- a/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
@@ -476,7 +476,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
     
     protected void showPopup(KeyStroke keyStroke) {
         popupWindow = new PopupWindow();
-        popupWindow.setPosition(toGlobal(new TerminalPosition(0, 1)));
+        popupWindow.setPosition(toGlobal(TerminalPosition.OF_0x1));
         ((WindowBasedTextGUI) getTextGUI()).addWindow(popupWindow);
         ((WindowBasedTextGUI) getTextGUI()).setActiveWindow(popupWindow);
     }
@@ -627,7 +627,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
         public TerminalPosition getCursorLocation(ComboBox<V> comboBox) {
             if(comboBox.isDropDownFocused()) {
                 if(comboBox.getThemeDefinition().isCursorVisible()) {
-                    return new TerminalPosition(comboBox.getSize().getColumns() - 1, 0);
+                    return TerminalPosition.of(comboBox.getSize().getColumns() - 1, 0);
                 }
                 else {
                     return null;
@@ -636,7 +636,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
             else {
                 int textInputPosition = comboBox.getTextInputPosition();
                 int textInputColumn = TerminalTextUtils.getColumnWidth(comboBox.getText().substring(0, textInputPosition));
-                return new TerminalPosition(textInputColumn - textVisibleLeftPosition, 0);
+                return TerminalPosition.of(textInputColumn - textVisibleLeftPosition, 0);
             }
         }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/Component.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Component.java
@@ -18,6 +18,7 @@
  */
 package com.googlecode.lanterna.gui2;
 
+import com.googlecode.lanterna.TerminalRectangle;
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.graphics.Theme;
@@ -30,6 +31,14 @@ import com.googlecode.lanterna.graphics.ThemeDefinition;
  * @author Martin
  */
 public interface Component extends TextGUIElement {
+
+    /**
+     *
+     * @return the TerminalPosition and TerminalSize as a TerminalRectangle
+     */
+    default TerminalRectangle getBounds() {
+        return new TerminalRectangle(getPosition(), getSize());
+    }
     /**
      * Returns the top-left corner of this component, measured from its parent.
      * @return Position of this component
@@ -38,7 +47,7 @@ public interface Component extends TextGUIElement {
     
     /**
      * Returns the top-left corner of this component in global coordinates space
-     * using {@link TerminalPosition#TOP_LEFT_CORNER} with
+     * using {@link TerminalPosition#OF_0x0} with
      * {@link #toGlobal(TerminalPosition)}
      * 
      * @return global position of this component

--- a/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowDecorationRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowDecorationRenderer.java
@@ -130,7 +130,7 @@ public class DefaultWindowDecorationRenderer implements WindowDecorationRenderer
         return contentAreaSize
                 .withRelativeColumns(2)
                 .withRelativeRows(2)
-                .max(new TerminalSize(titleWidth + minPadding, 1));  //Make sure the title fits!
+                .max(TerminalSize.of(titleWidth + minPadding, 1));  //Make sure the title fits!
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowDecorationRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowDecorationRenderer.java
@@ -69,8 +69,8 @@ public class DefaultWindowDecorationRenderer implements WindowDecorationRenderer
         else {
             graphics.applyThemeStyle(themeDefinition.getPreLight());
         }
-        graphics.drawLine(new TerminalPosition(0, drawableArea.getRows() - 2), new TerminalPosition(0, 1), verticalLine);
-        graphics.drawLine(new TerminalPosition(1, 0), new TerminalPosition(drawableArea.getColumns() - 2, 0), horizontalLine);
+        graphics.drawLine(TerminalPosition.of(0, drawableArea.getRows() - 2), TerminalPosition.OF_0x1, verticalLine);
+        graphics.drawLine(TerminalPosition.OF_1x0, TerminalPosition.of(drawableArea.getColumns() - 2, 0), horizontalLine);
         graphics.setCharacter(0, 0, topLeftCorner);
         graphics.setCharacter(0, drawableArea.getRows() - 1, bottomLeftCorner);
 
@@ -87,12 +87,12 @@ public class DefaultWindowDecorationRenderer implements WindowDecorationRenderer
 
         graphics.applyThemeStyle(themeDefinition.getNormal());
         graphics.drawLine(
-                new TerminalPosition(drawableArea.getColumns() - 1, 1),
-                new TerminalPosition(drawableArea.getColumns() - 1, drawableArea.getRows() - 2),
+                TerminalPosition.of(drawableArea.getColumns() - 1, 1),
+                TerminalPosition.of(drawableArea.getColumns() - 1, drawableArea.getRows() - 2),
                 verticalLine);
         graphics.drawLine(
-                new TerminalPosition(1, drawableArea.getRows() - 1),
-                new TerminalPosition(drawableArea.getColumns() - 2, drawableArea.getRows() - 1),
+                TerminalPosition.of(1, drawableArea.getRows() - 1),
+                TerminalPosition.of(drawableArea.getColumns() - 2, drawableArea.getRows() - 1),
                 horizontalLine);
 
         graphics.setCharacter(drawableArea.getColumns() - 1, 0, topRightCorner);
@@ -109,7 +109,7 @@ public class DefaultWindowDecorationRenderer implements WindowDecorationRenderer
         }
 
         return graphics.newTextGraphics(
-                new TerminalPosition(1, 1),
+                TerminalPosition.OF_1x1,
                 drawableArea
                         // Make sure we don't make the new graphic's area smaller than 0
                         .withRelativeColumns(-(Math.min(2, drawableArea.getColumns())))
@@ -133,10 +133,8 @@ public class DefaultWindowDecorationRenderer implements WindowDecorationRenderer
                 .max(new TerminalSize(titleWidth + minPadding, 1));  //Make sure the title fits!
     }
 
-    private static final TerminalPosition OFFSET = new TerminalPosition(1, 1);
-
     @Override
     public TerminalPosition getOffset(Window window) {
-        return OFFSET;
+        return TerminalPosition.OF_1x1;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowManager.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowManager.java
@@ -108,18 +108,18 @@ public class DefaultWindowManager implements WindowManager {
             //Don't place the window, assume the position is already set
         }
         else if(allWindows.isEmpty()) {
-            window.setPosition(TerminalPosition.OFFSET_1x1);
+            window.setPosition(TerminalPosition.OF_1x1);
         }
         else if(window.getHints().contains(Window.Hint.CENTERED)) {
             int left = (lastKnownScreenSize.getColumns() - expectedDecoratedSize.getColumns()) / 2;
             int top = (lastKnownScreenSize.getRows() - expectedDecoratedSize.getRows()) / 2;
-            window.setPosition(new TerminalPosition(left, top));
+            window.setPosition(TerminalPosition.of(left, top));
         }
         else {
             TerminalPosition nextPosition = allWindows.get(allWindows.size() - 1).getPosition().withRelative(2, 1);
             if(nextPosition.getColumn() + expectedDecoratedSize.getColumns() > lastKnownScreenSize.getColumns() ||
                     nextPosition.getRow() + expectedDecoratedSize.getRows() > lastKnownScreenSize.getRows()) {
-                nextPosition = TerminalPosition.OFFSET_1x1;
+                nextPosition = TerminalPosition.of(1, 1);
             }
             window.setPosition(nextPosition);
         }
@@ -164,11 +164,11 @@ public class DefaultWindowManager implements WindowManager {
         TerminalPosition position = window.getPosition();
 
         if(window.getHints().contains(Window.Hint.FULL_SCREEN)) {
-            position = TerminalPosition.TOP_LEFT_CORNER;
+            position = TerminalPosition.OF_0x0;
             size = screenSize;
         }
         else if(window.getHints().contains(Window.Hint.EXPANDED)) {
-            position = TerminalPosition.OFFSET_1x1;
+            position = TerminalPosition.OF_1x1;
             size = screenSize.withRelative(
                     -Math.min(4, screenSize.getColumns()),
                     -Math.min(3, screenSize.getRows()));
@@ -195,7 +195,7 @@ public class DefaultWindowManager implements WindowManager {
             if(window.getHints().contains(Window.Hint.CENTERED)) {
                 int left = (lastKnownScreenSize.getColumns() - size.getColumns()) / 2;
                 int top = (lastKnownScreenSize.getRows() - size.getRows()) / 2;
-                position = new TerminalPosition(left, top);
+                position = TerminalPosition.of(left, top);
             }
         }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowManager.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/DefaultWindowManager.java
@@ -72,7 +72,7 @@ public class DefaultWindowManager implements WindowManager {
             this.lastKnownScreenSize = initialScreenSize;
         }
         else {
-            this.lastKnownScreenSize = new TerminalSize(80, 24);
+            this.lastKnownScreenSize = TerminalSize.of(80, 24);
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/EmptySpace.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/EmptySpace.java
@@ -35,7 +35,7 @@ public class EmptySpace extends AbstractComponent<EmptySpace> {
      * Creates an EmptySpace with size 1x1 and a default color chosen from the theme
      */
     public EmptySpace() {
-        this(null, TerminalSize.ONE);
+        this(null, TerminalSize.OF_1x1);
     }
 
     /**
@@ -43,7 +43,7 @@ public class EmptySpace extends AbstractComponent<EmptySpace> {
      * @param color Color to use (null will make it use the theme)
      */
     public EmptySpace(TextColor color) {
-        this(color, TerminalSize.ONE);
+        this(color, TerminalSize.OF_1x1);
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/gui2/EmptyWindowDecorationRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/EmptyWindowDecorationRenderer.java
@@ -38,6 +38,6 @@ public class EmptyWindowDecorationRenderer implements WindowDecorationRenderer {
 
     @Override
     public TerminalPosition getOffset(Window window) {
-        return TerminalPosition.TOP_LEFT_CORNER;
+        return TerminalPosition.OF_0x0;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/FatWindowDecorationRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/FatWindowDecorationRenderer.java
@@ -119,8 +119,8 @@ public class FatWindowDecorationRenderer implements WindowDecorationRenderer {
         }
     }
 
-    private static final TerminalPosition OFFSET_WITH_TITLE = new TerminalPosition(1, 3);
-    private static final TerminalPosition OFFSET_WITHOUT_TITLE = new TerminalPosition(1, 1);
+    private static final TerminalPosition OFFSET_WITH_TITLE = TerminalPosition.of(1, 3);
+    private static final TerminalPosition OFFSET_WITHOUT_TITLE = TerminalPosition.of(1, 1);
 
     @Override
     public TerminalPosition getOffset(Window window) {

--- a/src/main/java/com/googlecode/lanterna/gui2/FatWindowDecorationRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/FatWindowDecorationRenderer.java
@@ -109,13 +109,13 @@ public class FatWindowDecorationRenderer implements WindowDecorationRenderer {
             return contentAreaSize
                     .withRelativeColumns(2)
                     .withRelativeRows(4)
-                    .max(new TerminalSize(TerminalTextUtils.getColumnWidth(window.getTitle()) + 4, 1));  //Make sure the title fits!
+                    .max(TerminalSize.of(TerminalTextUtils.getColumnWidth(window.getTitle()) + 4, 1));  //Make sure the title fits!
         }
         else {
             return contentAreaSize
                     .withRelativeColumns(2)
                     .withRelativeRows(2)
-                    .max(new TerminalSize(3, 1));
+                    .max(TerminalSize.of(3, 1));
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/GUIBackdrop.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/GUIBackdrop.java
@@ -32,7 +32,7 @@ public class GUIBackdrop extends EmptySpace {
 
             @Override
             public TerminalSize getPreferredSize(EmptySpace component) {
-                return TerminalSize.ONE;
+                return TerminalSize.OF_1x1;
             }
 
             @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
@@ -458,7 +458,7 @@ public class GridLayout implements LayoutManager {
 
         //Ok, all constraints are in place, we can start placing out components. To simplify, do it horizontally first
         //and vertically after
-        TerminalPosition tableCellTopLeft = TerminalPosition.TOP_LEFT_CORNER;
+        TerminalPosition tableCellTopLeft = TerminalPosition.OF_0x0;
         for(int y = 0; y < table.length; y++) {
             tableCellTopLeft = tableCellTopLeft.withColumn(0);
             for(int x = 0; x < table[y].length; x++) {

--- a/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
@@ -386,7 +386,7 @@ public class GridLayout implements LayoutManager {
 
     @Override
     public TerminalSize getPreferredSize(List<Component> components) {
-        TerminalSize preferredSize = TerminalSize.ZERO;
+        TerminalSize preferredSize = TerminalSize.OF_0x0;
         if(components.isEmpty()) {
             return preferredSize.withRelative(
                     leftMarginSize + rightMarginSize,
@@ -417,7 +417,7 @@ public class GridLayout implements LayoutManager {
         Component[][] table = buildTable(components);
         table = eliminateUnusedRowsAndColumns(table);
 
-        if(area.equals(TerminalSize.ZERO) ||
+        if(area.equals(TerminalSize.OF_0x0) ||
                 table.length == 0 ||
                 area.getColumns() <= leftMarginSize + rightMarginSize + ((table[0].length - 1) * horizontalSpacing) ||
                 area.getRows() <= bottomMarginSize + topMarginSize + ((table.length - 1) * verticalSpacing)) {

--- a/src/main/java/com/googlecode/lanterna/gui2/ImageComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ImageComponent.java
@@ -44,7 +44,7 @@ public class ImageComponent extends AbstractInteractableComponent {
         return new InteractableRenderer<ImageComponent>() {
             @Override
             public void drawComponent(TextGUIGraphics graphics, ImageComponent panel) {
-                graphics.drawImage(TerminalPosition.TOP_LEFT_CORNER, textImage);
+                graphics.drawImage(TerminalPosition.OF_0x0, textImage);
             }
             @Override
             public TerminalSize getPreferredSize(ImageComponent panel) {

--- a/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
@@ -48,7 +48,7 @@ public class InteractableLookupMap {
     }
 
     TerminalSize getSize() {
-        if (lookupMap.length==0) { return TerminalSize.ZERO; }
+        if (lookupMap.length==0) { return TerminalSize.OF_0x0; }
         return new TerminalSize(lookupMap[0].length, lookupMap.length);
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
@@ -57,7 +57,7 @@ public class InteractableLookupMap {
      * @param interactable Interactable to add to the lookup map
      */
     public synchronized void add(Interactable interactable) {
-        TerminalPosition topLeft = interactable.toBasePane(TerminalPosition.TOP_LEFT_CORNER);
+        TerminalPosition topLeft = interactable.toBasePane(TerminalPosition.OF_0x0);
         TerminalSize size = interactable.getSize();
         interactables.add(interactable);
         int index = interactables.size() - 1;
@@ -121,10 +121,10 @@ public class InteractableLookupMap {
             // If the currently active interactable component is not showing the cursor, use the top-left position
             // instead if we're going up, or the bottom-left position if we're going down
             if(isDown) {
-                startPosition = new TerminalPosition(0, interactable.getSize().getRows() - 1);
+                startPosition = TerminalPosition.of(0, interactable.getSize().getRows() - 1);
             }
             else {
-                startPosition = TerminalPosition.TOP_LEFT_CORNER;
+                startPosition = TerminalPosition.OF_0x0;
             }
         }
         else {
@@ -144,9 +144,9 @@ public class InteractableLookupMap {
         }
         Set<Interactable> disqualified = getDisqualifiedInteractables(startPosition, true);
         TerminalSize size = getSize();
-        int maxShiftLeft = interactable.toBasePane(TerminalPosition.TOP_LEFT_CORNER).getColumn();
+        int maxShiftLeft = interactable.toBasePane(TerminalPosition.OF_0x0).getColumn();
         maxShiftLeft = Math.max(maxShiftLeft, 0);
-        int maxShiftRight = interactable.toBasePane(new TerminalPosition(interactable.getSize().getColumns() - 1, 0)).getColumn();
+        int maxShiftRight = interactable.toBasePane(TerminalPosition.of(interactable.getSize().getColumns() - 1, 0)).getColumn();
         maxShiftRight = Math.min(maxShiftRight, size.getColumns() - 1);
         int maxShift = Math.max(startPosition.getColumn() - maxShiftLeft, maxShiftRight - startPosition.getRow());
         for (int searchRow = startPosition.getRow() + directionTerm;
@@ -201,10 +201,10 @@ public class InteractableLookupMap {
             // If the currently active interactable component is not showing the cursor, use the top-left position
             // instead if we're going left, or the top-right position if we're going right
             if(isRight) {
-                startPosition = new TerminalPosition(interactable.getSize().getColumns() - 1, 0);
+                startPosition = TerminalPosition.of(interactable.getSize().getColumns() - 1, 0);
             }
             else {
-                startPosition = TerminalPosition.TOP_LEFT_CORNER;
+                startPosition = TerminalPosition.OF_0x0;
             }
         }
         else {
@@ -224,9 +224,9 @@ public class InteractableLookupMap {
         }
         Set<Interactable> disqualified = getDisqualifiedInteractables(startPosition, false);
         TerminalSize size = getSize();
-        int maxShiftUp = interactable.toBasePane(TerminalPosition.TOP_LEFT_CORNER).getRow();
+        int maxShiftUp = interactable.toBasePane(TerminalPosition.OF_0x0).getRow();
         maxShiftUp = Math.max(maxShiftUp, 0);
-        int maxShiftDown = interactable.toBasePane(new TerminalPosition(0, interactable.getSize().getRows() - 1)).getRow();
+        int maxShiftDown = interactable.toBasePane(TerminalPosition.of(0, interactable.getSize().getRows() - 1)).getRow();
         maxShiftDown = Math.min(maxShiftDown, size.getRows() - 1);
         int maxShift = Math.max(startPosition.getRow() - maxShiftUp, maxShiftDown - startPosition.getRow());
         for(int searchColumn = startPosition.getColumn() + directionTerm;

--- a/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
@@ -49,7 +49,7 @@ public class InteractableLookupMap {
 
     TerminalSize getSize() {
         if (lookupMap.length==0) { return TerminalSize.OF_0x0; }
-        return new TerminalSize(lookupMap[0].length, lookupMap.length);
+        return TerminalSize.of(lookupMap[0].length, lookupMap.length);
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/gui2/Label.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Label.java
@@ -45,7 +45,7 @@ public class Label extends AbstractComponent<Label> {
      */
     public Label(String text) {
         this.lines = null;
-        this.labelSize = TerminalSize.ZERO;
+        this.labelSize = TerminalSize.OF_0x0;
         this.labelWidth = 0;
         this.foregroundColor = null;
         this.backgroundColor = null;
@@ -109,7 +109,7 @@ public class Label extends AbstractComponent<Label> {
      */
     protected TerminalSize getBounds(String[] lines, TerminalSize currentBounds) {
         if(currentBounds == null) {
-            currentBounds = TerminalSize.ZERO;
+            currentBounds = TerminalSize.OF_0x0;
         }
         currentBounds = currentBounds.withRows(lines.length);
         if(labelWidth == null || labelWidth == 0) {

--- a/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
@@ -230,7 +230,7 @@ public class LinearLayout implements LayoutManager {
         for(Component component: components) {
             if(remainingVerticalSpace <= 0) {
                 component.setPosition(TerminalPosition.OF_0x0);
-                component.setSize(TerminalSize.ZERO);
+                component.setSize(TerminalSize.OF_0x0);
             }
             else {
                 Alignment alignment = Alignment.BEGINNING;
@@ -382,7 +382,7 @@ public class LinearLayout implements LayoutManager {
         for(Component component: components) {
             if(remainingHorizontalSpace <= 0) {
                 component.setPosition(TerminalPosition.OF_0x0);
-                component.setSize(TerminalSize.ZERO);
+                component.setSize(TerminalSize.OF_0x0);
             }
             else {
                 Alignment alignment = Alignment.BEGINNING;

--- a/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
@@ -229,7 +229,7 @@ public class LinearLayout implements LayoutManager {
         int availableHorizontalSpace = area.getColumns();
         for(Component component: components) {
             if(remainingVerticalSpace <= 0) {
-                component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+                component.setPosition(TerminalPosition.OF_0x0);
                 component.setSize(TerminalSize.ZERO);
             }
             else {
@@ -381,7 +381,7 @@ public class LinearLayout implements LayoutManager {
         int availableVerticalSpace = area.getRows();
         for(Component component: components) {
             if(remainingHorizontalSpace <= 0) {
-                component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+                component.setPosition(TerminalPosition.OF_0x0);
                 component.setSize(TerminalSize.ZERO);
             }
             else {

--- a/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
@@ -177,7 +177,7 @@ public class LinearLayout implements LayoutManager {
             height += preferredSize.getRows();
         }
         height += spacing * (components.size() - 1);
-        return new TerminalSize(maxWidth, Math.max(0, height));
+        return TerminalSize.of(maxWidth, Math.max(0, height));
     }
 
     private TerminalSize getPreferredSizeHorizontally(List<Component> components) {
@@ -191,7 +191,7 @@ public class LinearLayout implements LayoutManager {
             width += preferredSize.getColumns();
         }
         width += spacing * (components.size() - 1);
-        return new TerminalSize(Math.max(0,width), maxHeight);
+        return TerminalSize.of(Math.max(0,width), maxHeight);
     }
 
     @Override
@@ -240,7 +240,7 @@ public class LinearLayout implements LayoutManager {
                 }
 
                 TerminalSize preferredSize = component.getPreferredSize();
-                TerminalSize decidedSize = new TerminalSize(
+                TerminalSize decidedSize = TerminalSize.of(
                         Math.min(availableHorizontalSpace, preferredSize.getColumns()),
                         Math.min(remainingVerticalSpace, preferredSize.getRows()));
                 if(alignment == Alignment.FILL) {
@@ -283,7 +283,7 @@ public class LinearLayout implements LayoutManager {
             }
 
             TerminalSize preferredSize = component.getPreferredSize();
-            TerminalSize fittingSize = new TerminalSize(
+            TerminalSize fittingSize = TerminalSize.of(
                     Math.min(availableHorizontalSpace, preferredSize.getColumns()),
                     preferredSize.getRows());
             if(alignment == Alignment.FILL) {
@@ -392,7 +392,7 @@ public class LinearLayout implements LayoutManager {
                 }
 
                 TerminalSize preferredSize = component.getPreferredSize();
-                TerminalSize decidedSize = new TerminalSize(
+                TerminalSize decidedSize = TerminalSize.of(
                         Math.min(remainingHorizontalSpace, preferredSize.getColumns()),
                         Math.min(availableVerticalSpace, preferredSize.getRows()));
                 if(alignment == Alignment.FILL) {
@@ -435,7 +435,7 @@ public class LinearLayout implements LayoutManager {
             }
 
             TerminalSize preferredSize = component.getPreferredSize();
-            TerminalSize fittingSize = new TerminalSize(
+            TerminalSize fittingSize = TerminalSize.of(
                     preferredSize.getColumns(),
                     Math.min(availableVerticalSpace, preferredSize.getRows()));
             if(alignment == Alignment.FILL) {

--- a/src/main/java/com/googlecode/lanterna/gui2/MenuPopupWindow.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MenuPopupWindow.java
@@ -38,7 +38,7 @@ public class MenuPopupWindow extends AbstractWindow {
     public MenuPopupWindow(Component parent) {
         setHints(Arrays.asList(Hint.MODAL, Hint.MENU_POPUP, Hint.FIXED_POSITION));
         if (parent != null) {
-            TerminalPosition menuPositionGlobal = parent.toGlobal(TerminalPosition.TOP_LEFT_CORNER);
+            TerminalPosition menuPositionGlobal = parent.toGlobal(TerminalPosition.OF_0x0);
             setPosition(menuPositionGlobal.withRelative(0, 1));
         }
         menuItemPanel = new Panel(new LinearLayout(Direction.VERTICAL));

--- a/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
@@ -265,7 +265,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
                 }
                 TextGUIGraphics windowGraphics = new DefaultTextGUIGraphics(this, textImage.newTextGraphics());
                 TextGUIGraphics insideWindowDecorationsGraphics = windowGraphics;
-                TerminalPosition contentOffset = TerminalPosition.TOP_LEFT_CORNER;
+                TerminalPosition contentOffset = TerminalPosition.OF_0x0;
                 if (!window.getHints().contains(Window.Hint.NO_DECORATIONS)) {
                     WindowDecorationRenderer decorationRenderer = windowManager.getWindowDecorationRenderer(window);
                     insideWindowDecorationsGraphics = decorationRenderer.draw(this, windowGraphics, window);
@@ -439,7 +439,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
             int dx = mp.getColumn() - dragStart.getColumn();
             int dy = mp.getRow() - dragStart.getRow();
             changeWindowHintsForDragged(titleBarDragWindow);
-            titleBarDragWindow.setPosition(new TerminalPosition(wp.getColumn() + dx, wp.getRow() + dy));
+            titleBarDragWindow.setPosition(TerminalPosition.of(wp.getColumn() + dx, wp.getRow() + dy));
             // TODO ? any additional children popups (shown menus, etc) should also be moved (or just closed)
         }
         

--- a/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
@@ -214,7 +214,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
         if (getScreen() instanceof VirtualScreen) {
             // If the user has passed in a virtual screen, we should calculate the minimum size required and tell it.
             // Previously the constructor always wrapped the screen in a VirtualScreen, but now we need to check.
-            TerminalSize minimumTerminalSize = TerminalSize.ZERO;
+            TerminalSize minimumTerminalSize = TerminalSize.OF_0x0;
             for (Window window : getWindows()) {
                 if (window.isVisible()) {
                     if (window.getHints().contains(Window.Hint.FULL_SCREEN) ||
@@ -464,7 +464,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
     public synchronized WindowBasedTextGUI addWindow(Window window) {
         //To protect against NPE if the user forgot to set a content component
         if(window.getComponent() == null) {
-            window.setComponent(new EmptySpace(TerminalSize.ONE));
+            window.setComponent(new EmptySpace(TerminalSize.OF_1x1));
         }
 
         if(window.getTextGUI() != null) {

--- a/src/main/java/com/googlecode/lanterna/gui2/ProgressBar.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ProgressBar.java
@@ -248,13 +248,13 @@ public class ProgressBar extends AbstractComponent<ProgressBar> {
         public TerminalSize getPreferredSize(ProgressBar component) {
             int preferredWidth = component.getPreferredWidth();
             if(preferredWidth > 0) {
-                return new TerminalSize(preferredWidth, 1);
+                return TerminalSize.of(preferredWidth, 1);
             }
             else if(component.getLabelFormat() != null && !component.getLabelFormat().trim().isEmpty()) {
-                return new TerminalSize(TerminalTextUtils.getColumnWidth(String.format(component.getLabelFormat(), 100.0f)) + 2, 1);
+                return TerminalSize.of(TerminalTextUtils.getColumnWidth(String.format(component.getLabelFormat(), 100.0f)) + 2, 1);
             }
             else {
-                return new TerminalSize(10, 1);
+                return TerminalSize.of(10, 1);
             }
         }
 
@@ -322,10 +322,10 @@ public class ProgressBar extends AbstractComponent<ProgressBar> {
         public TerminalSize getPreferredSize(ProgressBar component) {
             int preferredWidth = component.getPreferredWidth();
             if(preferredWidth > 0) {
-                return new TerminalSize(preferredWidth, 3);
+                return TerminalSize.of(preferredWidth, 3);
             }
             else {
-                return new TerminalSize(42, 3);
+                return TerminalSize.of(42, 3);
             }
         }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollBar.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollBar.java
@@ -152,7 +152,7 @@ public class ScrollBar extends AbstractComponent<ScrollBar> {
     public static abstract class ScrollBarRenderer implements ComponentRenderer<ScrollBar> {
         @Override
         public TerminalSize getPreferredSize(ScrollBar component) {
-            return TerminalSize.ONE;
+            return TerminalSize.OF_1x1;
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/Separator.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Separator.java
@@ -73,7 +73,7 @@ public class Separator extends AbstractComponent<Separator> {
     public static class DefaultSeparatorRenderer extends SeparatorRenderer {
         @Override
         public TerminalSize getPreferredSize(Separator component) {
-            return TerminalSize.ONE;
+            return TerminalSize.OF_1x1;
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
@@ -146,9 +146,9 @@ public class SplitPanel extends Panel {
             int tHeight = thumb.getPreferredSize().getRows();
 
             if (isHorizontal) {
-                return new TerminalSize(aWidth + tWidth + bWidth, Math.max(aHeight, Math.max(tHeight, bHeight)));
+                return TerminalSize.of(aWidth + tWidth + bWidth, Math.max(aHeight, Math.max(tHeight, bHeight)));
             } else {
-                return new TerminalSize(Math.max(aWidth, Math.max(tWidth, bWidth)), aHeight + tHeight + bHeight);
+                return TerminalSize.of(Math.max(aWidth, Math.max(tWidth, bWidth)), aHeight + tHeight + bHeight);
             }
         }
 
@@ -159,7 +159,7 @@ public class SplitPanel extends Panel {
             // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
             // TODO: themed
             int length = isHorizontal ? size.getRows() : size.getColumns();
-            TerminalSize tsize = new TerminalSize(isHorizontal ? 1 : length, !isHorizontal ? 1 : length);
+            TerminalSize tsize = TerminalSize.of(isHorizontal ? 1 : length, !isHorizontal ? 1 : length);
             TextImage textImage = new BasicTextImage(tsize);
             Theme theme = getTheme();
             ThemeDefinition themeDefinition = theme.getDefaultDefinition();
@@ -203,9 +203,9 @@ public class SplitPanel extends Panel {
                 int rightWidth = Math.max(0, w - leftWidth);
                 int rightHeight = Math.max(0, Math.min(compB.getPreferredSize().getRows(), h));
 
-                compA.setSize(new TerminalSize(leftWidth, leftHeight));
+                compA.setSize(TerminalSize.of(leftWidth, leftHeight));
                 thumb.setSize(thumb.getPreferredSize());
-                compB.setSize(new TerminalSize(rightWidth, rightHeight));
+                compB.setSize(TerminalSize.of(rightWidth, rightHeight));
 
                 compA.setPosition(TerminalPosition.of(0, 0));
                 thumb.setPosition(TerminalPosition.of(leftWidth, h / 2 - tHeight / 2));
@@ -217,9 +217,9 @@ public class SplitPanel extends Panel {
                 int rightWidth = Math.max(0, Math.min(compB.getPreferredSize().getColumns(), w));
                 int rightHeight = Math.max(0, h - leftHeight);
 
-                compA.setSize(new TerminalSize(leftWidth, leftHeight));
+                compA.setSize(TerminalSize.of(leftWidth, leftHeight));
                 thumb.setSize(thumb.getPreferredSize());
-                compB.setSize(new TerminalSize(rightWidth, rightHeight));
+                compB.setSize(TerminalSize.of(rightWidth, rightHeight));
 
                 compA.setPosition(TerminalPosition.of(0, 0));
                 thumb.setPosition(TerminalPosition.of(w / 2 - tWidth / 2, leftHeight));
@@ -261,7 +261,7 @@ public class SplitPanel extends Panel {
         if (visible) {
             this.setPreferredSize(null);
         } else {
-            thumb.setPreferredSize(new TerminalSize(1, 1));
+            thumb.setPreferredSize(TerminalSize.of(1, 1));
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
@@ -207,9 +207,9 @@ public class SplitPanel extends Panel {
                 thumb.setSize(thumb.getPreferredSize());
                 compB.setSize(new TerminalSize(rightWidth, rightHeight));
 
-                compA.setPosition(new TerminalPosition(0, 0));
-                thumb.setPosition(new TerminalPosition(leftWidth, h / 2 - tHeight / 2));
-                compB.setPosition(new TerminalPosition(leftWidth + tWidth, 0));
+                compA.setPosition(TerminalPosition.of(0, 0));
+                thumb.setPosition(TerminalPosition.of(leftWidth, h / 2 - tHeight / 2));
+                compB.setPosition(TerminalPosition.of(leftWidth + tWidth, 0));
             } else {
                 int leftWidth = Math.max(0, Math.min(compA.getPreferredSize().getColumns(), w));
                 int leftHeight = Math.max(0, (int) (h * ratio));
@@ -221,9 +221,9 @@ public class SplitPanel extends Panel {
                 thumb.setSize(thumb.getPreferredSize());
                 compB.setSize(new TerminalSize(rightWidth, rightHeight));
 
-                compA.setPosition(new TerminalPosition(0, 0));
-                thumb.setPosition(new TerminalPosition(w / 2 - tWidth / 2, leftHeight));
-                compB.setPosition(new TerminalPosition(0, leftHeight + tHeight));
+                compA.setPosition(TerminalPosition.of(0, 0));
+                thumb.setPosition(TerminalPosition.of(w / 2 - tWidth / 2, leftHeight));
+                compB.setPosition(TerminalPosition.of(0, leftHeight + tHeight));
             }
 
             hasChanged = !compAPrevPos.equals(compA.getPosition()) ||

--- a/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
@@ -74,7 +74,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
      * Default constructor, this creates a single-line {@code TextBox} of size 10 which is initially empty
      */
     public TextBox() {
-        this(new TerminalSize(10, 1), "", Style.SINGLE_LINE);
+        this(TerminalSize.of(10, 1), "", Style.SINGLE_LINE);
     }
 
     /**
@@ -148,7 +148,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
         this.caretPosition = TerminalPosition.of(getLine(0).length(), 0);
 
         if (preferredSize == null) {
-            preferredSize = new TerminalSize(Math.max(10, longestRow), lines.size());
+            preferredSize = TerminalSize.of(Math.max(10, longestRow), lines.size());
         }
         setPreferredSize(preferredSize);
     }
@@ -852,7 +852,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
 
         @Override
         public TerminalSize getPreferredSize(TextBox component) {
-            return new TerminalSize(component.longestRow, component.lines.size());
+            return TerminalSize.of(component.longestRow, component.lines.size());
         }
 
         /**
@@ -897,7 +897,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 verticalScrollBar.setScrollPosition(viewTopLeft.getRow());
                 verticalScrollBar.draw(graphics.newTextGraphics(
                         TerminalPosition.of(graphics.getSize().getColumns() - 1, 0),
-                        new TerminalSize(1, graphics.getSize().getRows() - (drawHorizontalScrollBar ? 1 : 0))));
+                        TerminalSize.of(1, graphics.getSize().getRows() - (drawHorizontalScrollBar ? 1 : 0))));
             }
             if(drawHorizontalScrollBar) {
                 horizontalScrollBar.onAdded(component.getParent());
@@ -906,7 +906,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 horizontalScrollBar.setScrollPosition(viewTopLeft.getColumn());
                 horizontalScrollBar.draw(graphics.newTextGraphics(
                         TerminalPosition.of(0, graphics.getSize().getRows() - 1),
-                        new TerminalSize(graphics.getSize().getColumns() - (drawVerticalScrollBar ? 1 : 0), 1)));
+                        TerminalSize.of(graphics.getSize().getColumns() - (drawVerticalScrollBar ? 1 : 0), 1)));
             }
         }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
@@ -136,7 +136,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
         this.caretWarp = false;
         this.verticalFocusSwitching = true;
         this.horizontalFocusSwitching = (style == Style.SINGLE_LINE);
-        this.caretPosition = TerminalPosition.TOP_LEFT_CORNER;
+        this.caretPosition = TerminalPosition.OF_0x0;
         this.maxLineLength = -1;
         this.longestRow = 1;    //To fit the cursor
         this.mask = null;
@@ -145,7 +145,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
         setText(initialContent);
 
         // Re-adjust caret position
-        this.caretPosition = TerminalPosition.TOP_LEFT_CORNER.withColumn(getLine(0).length());
+        this.caretPosition = TerminalPosition.of(getLine(0).length(), 0);
 
         if (preferredSize == null) {
             preferredSize = new TerminalSize(Math.max(10, longestRow), lines.size());
@@ -676,7 +676,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                         int maxPositionAttempt = newActiveLine.length();
                         newCaretPositionColumn = Math.max(minPositionAttempt, Math.min(newCaretPositionColumn, maxPositionAttempt));
 
-                        caretPosition = caretPosition.with(new TerminalPosition(newCaretPositionColumn, newCaretPositionRow));
+                        caretPosition = caretPosition.with(TerminalPosition.of(newCaretPositionColumn, newCaretPositionRow));
                     }
                 }
                 result = Result.HANDLED;
@@ -749,10 +749,10 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 getRenderer().setViewTopLeft(getRenderer().getViewTopLeft().withRelativeRow(1));
                 return Result.HANDLED;
             case HOME:
-                getRenderer().setViewTopLeft(TerminalPosition.TOP_LEFT_CORNER);
+                getRenderer().setViewTopLeft(TerminalPosition.OF_0x0);
                 return Result.HANDLED;
             case END:
-                getRenderer().setViewTopLeft(TerminalPosition.TOP_LEFT_CORNER.withRow(getLineCount() - getSize().getRows()));
+                getRenderer().setViewTopLeft(TerminalPosition.of(0, getLineCount() - getSize().getRows()));
                 return Result.HANDLED;
             case PAGE_DOWN:
                 getRenderer().setViewTopLeft(getRenderer().getViewTopLeft().withRelativeRow(getSize().getRows()));
@@ -797,7 +797,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
          * Default constructor
          */
         public DefaultTextBoxRenderer() {
-            viewTopLeft = TerminalPosition.TOP_LEFT_CORNER;
+            viewTopLeft = TerminalPosition.OF_0x0;
             verticalScrollBar = new ScrollBar(Direction.VERTICAL);
             horizontalScrollBar = new ScrollBar(Direction.HORIZONTAL);
             hideScrollBars = false;
@@ -887,7 +887,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 }
             }
 
-            drawTextArea(graphics.newTextGraphics(TerminalPosition.TOP_LEFT_CORNER, realTextArea), component);
+            drawTextArea(graphics.newTextGraphics(TerminalPosition.OF_0x0, realTextArea), component);
 
             //Draw scrollbars, if any
             if(drawVerticalScrollBar) {
@@ -896,7 +896,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 verticalScrollBar.setScrollMaximum(textBoxLineCount);
                 verticalScrollBar.setScrollPosition(viewTopLeft.getRow());
                 verticalScrollBar.draw(graphics.newTextGraphics(
-                        new TerminalPosition(graphics.getSize().getColumns() - 1, 0),
+                        TerminalPosition.of(graphics.getSize().getColumns() - 1, 0),
                         new TerminalSize(1, graphics.getSize().getRows() - (drawHorizontalScrollBar ? 1 : 0))));
             }
             if(drawHorizontalScrollBar) {
@@ -905,7 +905,7 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 horizontalScrollBar.setScrollMaximum(component.longestRow - 1);
                 horizontalScrollBar.setScrollPosition(viewTopLeft.getColumn());
                 horizontalScrollBar.draw(graphics.newTextGraphics(
-                        new TerminalPosition(0, graphics.getSize().getRows() - 1),
+                        TerminalPosition.of(0, graphics.getSize().getRows() - 1),
                         new TerminalSize(graphics.getSize().getColumns() - (drawVerticalScrollBar ? 1 : 0), 1)));
             }
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -56,7 +56,7 @@ public class ActionListDialog extends DialogWindow {
                         .setRightMarginSize(1));
         if(description != null) {
             mainPanel.addComponent(new Label(description));
-            mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+            mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         }
         listBox.setLayoutData(
                 GridLayout.createLayoutData(
@@ -65,7 +65,7 @@ public class ActionListDialog extends DialogWindow {
                         true,
                         false))
                 .addTo(mainPanel);
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
 
         if(canCancel) {
             Panel buttonPanel = new Panel();

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/DirectoryDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/DirectoryDialog.java
@@ -93,10 +93,10 @@ public class DirectoryDialog extends DialogWindow {
 
         int unitHeight = dialogSize.getRows();
 
-        dirListBox = new ActionListBox(new TerminalSize(dialogSize.getColumns(), unitHeight));
+        dirListBox = new ActionListBox(TerminalSize.of(dialogSize.getColumns(), unitHeight));
         dirsPane.addComponent(dirListBox.withBorder(Borders.singleLine()), Location.CENTER);
 
-        dirBox = new TextBox(new TerminalSize(dialogSize.getColumns(), 1));
+        dirBox = new TextBox(TerminalSize.of(dialogSize.getColumns(), 1));
         dirsPane.addComponent(dirBox.withBorder(Borders.singleLine()), Location.BOTTOM);
 
         Panel panelButtons = new Panel(new GridLayout(2));

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/DirectoryDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/DirectoryDialogBuilder.java
@@ -48,7 +48,7 @@ public class DirectoryDialogBuilder extends AbstractDialogBuilder<DirectoryDialo
     public DirectoryDialogBuilder() {
         super("DirectoryDialog");
         actionLabel = LocalizedString.OK.toString();
-        suggestedSize = new TerminalSize(45, 10);
+        suggestedSize = TerminalSize.of(45, 10);
         showHiddenDirectories = false;
         selectedDir = null;
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
@@ -237,7 +237,7 @@ public class FileDialog extends DialogWindow {
     private class FileSystemLocationLabel extends Label {
         public FileSystemLocationLabel() {
             super("");
-            setPreferredSize(TerminalSize.ONE);
+            setPreferredSize(TerminalSize.OF_1x1);
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
@@ -96,7 +96,7 @@ public class FileDialog extends DialogWindow {
                         1))
                 .addTo(contentPane);
 
-        fileListBox = new ActionListBox(new TerminalSize(unitWidth * 2, unitHeight));
+        fileListBox = new ActionListBox(TerminalSize.of(unitWidth * 2, unitHeight));
         fileListBox.withBorder(Borders.singleLine())
                 .setLayoutData(GridLayout.createLayoutData(
                         GridLayout.Alignment.BEGINNING,
@@ -104,7 +104,7 @@ public class FileDialog extends DialogWindow {
                         false,
                         false))
                 .addTo(contentPane);
-        directoryListBox = new ActionListBox(new TerminalSize(unitWidth, unitHeight));
+        directoryListBox = new ActionListBox(TerminalSize.of(unitWidth, unitHeight));
         directoryListBox.withBorder(Borders.singleLine())
                 .addTo(contentPane);
 

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialogBuilder.java
@@ -41,7 +41,7 @@ public class FileDialogBuilder extends AbstractDialogBuilder<FileDialogBuilder, 
     public FileDialogBuilder() {
         super("FileDialog");
         actionLabel = LocalizedString.OK.toString();
-        suggestedSize = new TerminalSize(45, 10);
+        suggestedSize = TerminalSize.of(45, 10);
         showHiddenDirectories = false;
         selectedFile = null;
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
@@ -58,7 +58,7 @@ public class ListSelectDialog<T> extends DialogWindow {
                         .setRightMarginSize(1));
         if(description != null) {
             mainPanel.addComponent(new Label(description));
-            mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+            mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         }
         listBox.setLayoutData(
                 GridLayout.createLayoutData(
@@ -67,7 +67,7 @@ public class ListSelectDialog<T> extends DialogWindow {
                         true,
                         false))
                 .addTo(mainPanel);
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
 
         if(canCancel) {
             Panel buttonPanel = new Panel();

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
@@ -137,7 +137,7 @@ public class ListSelectDialog<T> extends DialogWindow {
             width = Math.max(width, TerminalTextUtils.getColumnWidth(item.toString()));
         }
         width += 2;
-        return showDialog(textGUI, title, description, new TerminalSize(width, listBoxHeight), items);
+        return showDialog(textGUI, title, description, TerminalSize.of(width, listBoxHeight), items);
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialog.java
@@ -56,7 +56,7 @@ public class MessageDialog extends DialogWindow {
                         .setLeftMarginSize(1)
                         .setRightMarginSize(1));
         mainPanel.addComponent(new Label(text));
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         buttonPanel.setLayoutData(
                 GridLayout.createLayoutData(
                         GridLayout.Alignment.END,

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialog.java
@@ -65,7 +65,7 @@ public class TextInputDialog extends DialogWindow {
         if(description != null) {
             mainPanel.addComponent(new Label(description));
         }
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         textBox.setLayoutData(
                 GridLayout.createLayoutData(
                         GridLayout.Alignment.FILL,
@@ -73,7 +73,7 @@ public class TextInputDialog extends DialogWindow {
                         true,
                         false))
                 .addTo(mainPanel);
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         buttonPanel.setLayoutData(
                 GridLayout.createLayoutData(
                         GridLayout.Alignment.END,

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialogBuilder.java
@@ -53,7 +53,7 @@ public class TextInputDialogBuilder extends AbstractDialogBuilder<TextInputDialo
     protected TextInputDialog buildDialog() {
         TerminalSize size = textBoxSize;
         if ((initialContent == null || initialContent.trim().equals("")) && size == null) {
-            size = new TerminalSize(40, 1);
+            size = TerminalSize.of(40, 1);
         }
         return new TextInputDialog(
                 title,

--- a/src/main/java/com/googlecode/lanterna/gui2/menu/MenuBar.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/menu/MenuBar.java
@@ -189,7 +189,7 @@ public class MenuBar extends AbstractComponent<MenuBar> implements Container {
                 totalWidth += preferredSize.getColumns();
             }
             totalWidth += EXTRA_PADDING;
-            return new TerminalSize(totalWidth, maxHeight);
+            return TerminalSize.of(totalWidth, maxHeight);
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/menu/MenuItem.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/menu/MenuItem.java
@@ -125,7 +125,7 @@ public class MenuItem extends AbstractInteractableComponent<MenuItem> {
             if (component instanceof Menu && !(component.getParent() instanceof MenuBar)) {
                 preferredWidth += 2;
             }
-            return TerminalSize.ONE.withColumns(preferredWidth);
+            return TerminalSize.OF_1x1.withColumns(preferredWidth);
         }
 
         @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableCellRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableCellRenderer.java
@@ -39,7 +39,7 @@ public class DefaultTableCellRenderer<V> implements TableCellRenderer<V> {
                 maxWidth = length;
             }
         }
-        return new TerminalSize(maxWidth, lines.length);
+        return TerminalSize.of(maxWidth, lines.length);
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableHeaderRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableHeaderRenderer.java
@@ -33,7 +33,7 @@ public class DefaultTableHeaderRenderer<V> implements TableHeaderRenderer<V> {
         if(label == null) {
             return TerminalSize.OF_0x0;
         }
-        return new TerminalSize(TerminalTextUtils.getColumnWidth(label), 1);
+        return TerminalSize.of(TerminalTextUtils.getColumnWidth(label), 1);
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableHeaderRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableHeaderRenderer.java
@@ -31,7 +31,7 @@ public class DefaultTableHeaderRenderer<V> implements TableHeaderRenderer<V> {
     @Override
     public TerminalSize getPreferredSize(Table<V> table, String label, int columnIndex) {
         if(label == null) {
-            return TerminalSize.ZERO;
+            return TerminalSize.OF_0x0;
         }
         return new TerminalSize(TerminalTextUtils.getColumnWidth(label), 1);
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
@@ -221,7 +221,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
         preferredRowSizes.clear();
 
         if(tableModel.getColumnCount() == 0) {
-            return TerminalSize.ZERO;
+            return TerminalSize.OF_0x0;
         }
 
         // Adjust view port if necessary (although this is only for the preferred size calculation, we don't actually

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
@@ -358,7 +358,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
             }
         }
 
-        cachedSize = new TerminalSize(preferredColumnSize, preferredRowSize);
+        cachedSize = TerminalSize.of(preferredColumnSize, preferredRowSize);
         return cachedSize;
     }
 
@@ -541,7 +541,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
         int endColumnIndex = Math.min(headers.size(), viewLeftColumn + visibleColumns);
         for(int index = viewLeftColumn; index < endColumnIndex; index++) {
             String label = headers.get(index);
-            TerminalSize size = new TerminalSize(columnSizes.get(index), headerSizeInRows);
+            TerminalSize size = TerminalSize.of(columnSizes.get(index), headerSizeInRows);
             tableHeaderRenderer.drawHeader(table, label, index, graphics.newTextGraphics(TerminalPosition.of(leftPosition, 0), size));
             leftPosition += size.getColumns();
             if(headerHorizontalBorderStyle != TableCellBorderStyle.NONE && index < (endColumnIndex - 1)) {
@@ -672,7 +672,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
                 }
                 V cell = row.get(columnIndex);
                 TerminalPosition cellPosition = TerminalPosition.of(leftPosition, topPosition);
-                TerminalSize cellArea = new TerminalSize(columnSizes.get(columnIndex), preferredRowSizes.get(rowIndex));
+                TerminalSize cellArea = TerminalSize.of(columnSizes.get(columnIndex), preferredRowSizes.get(rowIndex));
                 tableCellRenderer.drawCell(table, cell, columnIndex, rowIndex, graphics.newTextGraphics(cellPosition, cellArea));
                 leftPosition += cellArea.getColumns();
 

--- a/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/DefaultTableRenderer.java
@@ -449,7 +449,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
         List<Integer> columnSizes = fitColumnsInAvailableSpace(table, areaWithoutScrollBars, visibleColumns);
         drawHeader(graphics, table, columnSizes);
         drawRows(graphics.newTextGraphics(
-                        new TerminalPosition(0, headerSizeIncludingBorder),
+                        TerminalPosition.of(0, headerSizeIncludingBorder),
                         // Can't use areaWithoutScrollBars here because we need to draw the scrollbar too!
                         area.withRelativeRows(-headerSizeIncludingBorder)),
                 table,
@@ -542,7 +542,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
         for(int index = viewLeftColumn; index < endColumnIndex; index++) {
             String label = headers.get(index);
             TerminalSize size = new TerminalSize(columnSizes.get(index), headerSizeInRows);
-            tableHeaderRenderer.drawHeader(table, label, index, graphics.newTextGraphics(new TerminalPosition(leftPosition, 0), size));
+            tableHeaderRenderer.drawHeader(table, label, index, graphics.newTextGraphics(TerminalPosition.of(leftPosition, 0), size));
             leftPosition += size.getColumns();
             if(headerHorizontalBorderStyle != TableCellBorderStyle.NONE && index < (endColumnIndex - 1)) {
                 graphics.applyThemeStyle(theme.getDefinition(Table.class).getNormal());
@@ -602,7 +602,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
             if(needHorizontalScrollBar) {
                 scrollBarHeight--;
             }
-            verticalScrollBar.setPosition(new TerminalPosition(graphics.getSize().getColumns() - verticalScrollBarPreferredSize.getColumns(), 0));
+            verticalScrollBar.setPosition(TerminalPosition.of(graphics.getSize().getColumns() - verticalScrollBarPreferredSize.getColumns(), 0));
             verticalScrollBar.setSize(verticalScrollBarPreferredSize.withRows(scrollBarHeight));
             verticalScrollBar.setScrollMaximum(rows.size());
             verticalScrollBar.setViewSize(visibleRows);
@@ -622,12 +622,12 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
             verticalScrollBar.draw(graphics.newTextGraphics(verticalScrollBar.getPosition(), verticalScrollBar.getSize()));
 
             // Adjust graphics object to the remaining area when the vertical scrollbar is subtracted
-            graphics = graphics.newTextGraphics(TerminalPosition.TOP_LEFT_CORNER, graphics.getSize().withRelativeColumns(-verticalScrollBarPreferredSize.getColumns()));
+            graphics = graphics.newTextGraphics(TerminalPosition.OF_0x0, graphics.getSize().withRelativeColumns(-verticalScrollBarPreferredSize.getColumns()));
         }
         if(needHorizontalScrollBar) {
             TerminalSize horizontalScrollBarPreferredSize = horizontalScrollBar.getPreferredSize();
             int scrollBarWidth = graphics.getSize().getColumns();
-            horizontalScrollBar.setPosition(new TerminalPosition(0, graphics.getSize().getRows() - horizontalScrollBarPreferredSize.getRows()));
+            horizontalScrollBar.setPosition(TerminalPosition.of(0, graphics.getSize().getRows() - horizontalScrollBarPreferredSize.getRows()));
             horizontalScrollBar.setSize(horizontalScrollBarPreferredSize.withColumns(scrollBarWidth));
             horizontalScrollBar.setScrollMaximum(tableModel.getColumnCount());
             horizontalScrollBar.setViewSize(visibleColumns);
@@ -647,7 +647,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
             horizontalScrollBar.draw(graphics.newTextGraphics(horizontalScrollBar.getPosition(), horizontalScrollBar.getSize()));
 
             // Adjust graphics object to the remaining area when the horizontal scrollbar is subtracted
-            graphics = graphics.newTextGraphics(TerminalPosition.TOP_LEFT_CORNER, graphics.getSize().withRelativeRows(-horizontalScrollBarPreferredSize.getRows()));
+            graphics = graphics.newTextGraphics(TerminalPosition.OF_0x0, graphics.getSize().withRelativeRows(-horizontalScrollBarPreferredSize.getRows()));
         }
 
         int topPosition = 0;
@@ -671,7 +671,7 @@ public class DefaultTableRenderer<V> implements TableRenderer<V> {
                     leftPosition++;
                 }
                 V cell = row.get(columnIndex);
-                TerminalPosition cellPosition = new TerminalPosition(leftPosition, topPosition);
+                TerminalPosition cellPosition = TerminalPosition.of(leftPosition, topPosition);
                 TerminalSize cellArea = new TerminalSize(columnSizes.get(columnIndex), preferredRowSizes.get(rowIndex));
                 tableCellRenderer.drawCell(table, cell, columnIndex, rowIndex, graphics.newTextGraphics(cellPosition, cellArea));
                 leftPosition += cellArea.getColumns();

--- a/src/main/java/com/googlecode/lanterna/input/MouseCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/MouseCharacterPattern.java
@@ -112,7 +112,7 @@ public class MouseCharacterPattern implements CharacterPattern {
         // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
         
         
-        TerminalPosition pos = new TerminalPosition( seq.get(4) - 33, seq.get(5) - 33 );
+        TerminalPosition pos = TerminalPosition.of( seq.get(4) - 33, seq.get(5) - 33 );
 
         MouseAction ma = new MouseAction(actionType, button, pos );
         return new Matching( ma ); // yep

--- a/src/main/java/com/googlecode/lanterna/input/ScreenInfoCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/ScreenInfoCharacterPattern.java
@@ -38,7 +38,7 @@ public class ScreenInfoCharacterPattern extends EscapeSequenceCharacterPattern {
         if (num1 == 1 && num2 <= 8) {
             return null; // nope: much more likely it's an F3 with modifiers
         }
-        TerminalPosition pos = new TerminalPosition(num2, num1);
+        TerminalPosition pos = TerminalPosition.of(num2, num1);
         return new ScreenInfoAction(pos); // yep
     }
 
@@ -53,7 +53,7 @@ public class ScreenInfoCharacterPattern extends EscapeSequenceCharacterPattern {
             int col = 1 + (ks.isAltDown()  ? ALT  : 0)
                         + (ks.isCtrlDown() ? CTRL : 0)
                         + (ks.isShiftDown()? SHIFT: 0);
-            TerminalPosition pos = new TerminalPosition(col,1);
+            TerminalPosition pos = TerminalPosition.of(col,1);
             return new ScreenInfoAction(pos);
         default:  return null;
         }

--- a/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
@@ -65,7 +65,7 @@ public abstract class AbstractScreen implements Screen {
         this.frontBuffer = new ScreenBuffer(initialSize, defaultCharacter);
         this.backBuffer = new ScreenBuffer(initialSize, defaultCharacter);
         this.defaultCharacter = defaultCharacter;
-        this.cursorPosition = new TerminalPosition(0, 0);
+        this.cursorPosition = TerminalPosition.OF_0x0;
         this.tabBehaviour = TabBehaviour.ALIGN_TO_COLUMN_4;
         this.terminalSize = initialSize;
         this.latestResizeRequest = null;

--- a/src/main/java/com/googlecode/lanterna/screen/Screen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/Screen.java
@@ -80,7 +80,7 @@ public interface Screen extends InputProvider, Scrollable, Closeable {
     /**
      * Erases all the characters on the screen, effectively giving you a blank area. The default background color will
      * be used. This is effectively the same as calling 
-     * <pre>fill(TerminalPosition.TOP_LEFT_CORNER, getSize(), TextColor.ANSI.Default)</pre>.
+     * <pre>fill(TerminalPosition.of(0, 0), getSize(), TextColor.ANSI.Default)</pre>.
      * <p>
      * Please note that calling this method will only affect the back buffer, you need to call refresh to make the 
      * change visible.

--- a/src/main/java/com/googlecode/lanterna/screen/TerminalScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/TerminalScreen.java
@@ -198,13 +198,13 @@ public class TerminalScreen extends AbstractScreen {
                 TextCharacter backBufferCharacter = getBackBuffer().getCharacterAt(x, y);
                 TextCharacter frontBufferCharacter = getFrontBuffer().getCharacterAt(x, y);
                 if(!backBufferCharacter.equals(frontBufferCharacter)) {
-                    updateMap.put(new TerminalPosition(x, y), backBufferCharacter);
+                    updateMap.put(TerminalPosition.of(x, y), backBufferCharacter);
                 }
                 if(backBufferCharacter.isDoubleWidth()) {
                     x++;    //Skip the trailing padding
                 } else if (frontBufferCharacter.isDoubleWidth()) {
                     if (x+1 < terminalSize.getColumns()) {
-                        updateMap.put(new TerminalPosition(x+1, y), frontBufferCharacter.withCharacter(' '));
+                        updateMap.put(TerminalPosition.of(x+1, y), frontBufferCharacter.withCharacter(' '));
                     }
                 }
             }

--- a/src/main/java/com/googlecode/lanterna/screen/VirtualScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/VirtualScreen.java
@@ -56,7 +56,7 @@ public class VirtualScreen extends AbstractScreen {
         this.frameRenderer = new DefaultFrameRenderer();
         this.realScreen = screen;
         this.minimumSize = screen.getTerminalSize();
-        this.viewportTopLeft = TerminalPosition.TOP_LEFT_CORNER;
+        this.viewportTopLeft = TerminalPosition.OF_0x0;
         this.viewportSize = minimumSize;
         this.scrollWithCTRL = false;
     }
@@ -163,7 +163,7 @@ public class VirtualScreen extends AbstractScreen {
         TerminalSize newVirtualSize = minimumSize.max(realTerminalSize);
         if(newVirtualSize.equals(realTerminalSize)) {
             viewportSize = realTerminalSize;
-            viewportTopLeft = TerminalPosition.TOP_LEFT_CORNER;
+            viewportTopLeft = TerminalPosition.OF_0x0;
         }
         else {
             TerminalSize newViewportSize = frameRenderer.getViewportSize(realTerminalSize, newVirtualSize);
@@ -324,7 +324,7 @@ public class VirtualScreen extends AbstractScreen {
 
         /**
          * Where in the virtual screen should the top-left position of the viewport be? To draw the viewport from the
-         * top-left position of the screen, return 0x0 (or TerminalPosition.TOP_LEFT_CORNER) here.
+         * top-left position of the screen, return 0x0 (or TerminalPosition.OF_0x0) here.
          * @return Position of the top-left corner of the viewport inside the screen
          */
         TerminalPosition getViewportOffset();
@@ -357,7 +357,7 @@ public class VirtualScreen extends AbstractScreen {
 
         @Override
         public TerminalPosition getViewportOffset() {
-            return TerminalPosition.TOP_LEFT_CORNER;
+            return TerminalPosition.OF_0x0;
         }
 
         @Override
@@ -381,16 +381,16 @@ public class VirtualScreen extends AbstractScreen {
             int scrollable = viewportSize.getColumns() - horizontalSize - 1;
             int horizontalPosition = (int)((double)scrollable * ((double)virtualScrollPosition.getColumn() / (double)(virtualSize.getColumns() - viewportSize.getColumns())));
             graphics.drawLine(
-                    new TerminalPosition(horizontalPosition, graphics.getSize().getRows() - 2),
-                    new TerminalPosition(horizontalPosition + horizontalSize, graphics.getSize().getRows() - 2),
+                    TerminalPosition.of(horizontalPosition, graphics.getSize().getRows() - 2),
+                    TerminalPosition.of(horizontalPosition + horizontalSize, graphics.getSize().getRows() - 2),
                     Symbols.BLOCK_MIDDLE);
 
             int verticalSize = (int)(((double)(viewportSize.getRows()) / (double)virtualSize.getRows()) * (viewportSize.getRows()));
             scrollable = viewportSize.getRows() - verticalSize - 1;
             int verticalPosition = (int)((double)scrollable * ((double)virtualScrollPosition.getRow() / (double)(virtualSize.getRows() - viewportSize.getRows())));
             graphics.drawLine(
-                    new TerminalPosition(graphics.getSize().getColumns() - 1, verticalPosition),
-                    new TerminalPosition(graphics.getSize().getColumns() - 1, verticalPosition + verticalSize),
+                    TerminalPosition.of(graphics.getSize().getColumns() - 1, verticalPosition),
+                    TerminalPosition.of(graphics.getSize().getColumns() - 1, verticalPosition + verticalSize),
                     Symbols.BLOCK_MIDDLE);
         }
     }

--- a/src/main/java/com/googlecode/lanterna/terminal/AbstractTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/AbstractTerminal.java
@@ -63,7 +63,7 @@ public abstract class AbstractTerminal implements Terminal {
      * @param rows Number of rows in the new size
      */
     protected synchronized void onResized(int columns, int rows) {
-        onResized(new TerminalSize(columns, rows));
+        onResized(TerminalSize.of(columns, rows));
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/terminal/TerminalTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/TerminalTextGraphics.java
@@ -62,7 +62,7 @@ class TerminalTextGraphics extends AbstractTextGraphics {
 
     @Override
     public TextGraphics setCharacter(int columnIndex, int rowIndex, TextCharacter textCharacter) {
-        return setCharacter(new TerminalPosition(columnIndex, rowIndex), textCharacter);
+        return setCharacter(TerminalPosition.of(columnIndex, rowIndex), textCharacter);
     }
 
     @Override
@@ -96,7 +96,7 @@ class TerminalTextGraphics extends AbstractTextGraphics {
 
     @Override
     public TextCharacter getCharacter(int column, int row) {
-        return getCharacter(new TerminalPosition(column, row));
+        return getCharacter(TerminalPosition.of(column, row));
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
@@ -109,7 +109,7 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
         if (terminalPosition == null) {
             terminalPosition = TerminalPosition.of(80,24);
         }
-        return new TerminalSize(terminalPosition.getColumn(), terminalPosition.getRow());
+        return TerminalSize.of(terminalPosition.getColumn(), terminalPosition.getRow());
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
@@ -107,7 +107,7 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
         restoreCursorPosition();
         TerminalPosition terminalPosition = waitForCursorPositionReport();
         if (terminalPosition == null) {
-            terminalPosition = new TerminalPosition(80,24);
+            terminalPosition = TerminalPosition.of(80,24);
         }
         return new TerminalSize(terminalPosition.getColumn(), terminalPosition.getRow());
     }
@@ -270,7 +270,7 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
         // ANSI terminal positions are 1-indexed so top-left corner is 1x1 instead of 0x0, that's why we need to adjust it here
         TerminalPosition terminalPosition = waitForCursorPositionReport();
         if (terminalPosition == null) {
-            terminalPosition = TerminalPosition.OFFSET_1x1;
+            terminalPosition = TerminalPosition.OF_1x1;
         }
         return terminalPosition.withRelative(-1, -1);
     }

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/CygwinTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/CygwinTerminal.java
@@ -73,14 +73,14 @@ public class CygwinTerminal extends UnixLikeTTYTerminal {
             String stty = runSTTYCommand("-a");
             Matcher matcher = STTY_SIZE_PATTERN.matcher(stty);
             if(matcher.matches()) {
-                return new TerminalSize(Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(1)));
+                return TerminalSize.of(Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(1)));
             }
             else {
-                return new TerminalSize(80, 24);
+                return TerminalSize.of(80, 24);
             }
         }
         catch(Throwable e) {
-            return new TerminalSize(80, 24);
+            return TerminalSize.of(80, 24);
         }
     }
 

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
@@ -690,7 +690,7 @@ abstract class GraphicalTerminalImplementation implements IOSafeTerminal {
 
     @Override
     public synchronized void setCursorPosition(int x, int y) {
-        setCursorPosition(new TerminalPosition(x, y));
+        setCursorPosition(TerminalPosition.of(x, y));
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
@@ -104,7 +104,7 @@ abstract class GraphicalTerminalImplementation implements IOSafeTerminal {
         //This is kind of meaningless since we don't know how large the
         //component is at this point, but we should set it to something
         if(initialTerminalSize == null) {
-            initialTerminalSize = new TerminalSize(80, 24);
+            initialTerminalSize = TerminalSize.of(80, 24);
         }
         this.virtualTerminal = new DefaultVirtualTerminal(initialTerminalSize);
         this.keyQueue = new LinkedBlockingQueue<>();

--- a/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
@@ -82,8 +82,8 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
         this.wholeBufferDirty = false;
         this.terminalSize = initialTerminalSize;
         this.cursorVisible = true;
-        this.cursorPosition = TerminalPosition.TOP_LEFT_CORNER;
-        this.savedCursorPosition = TerminalPosition.TOP_LEFT_CORNER;
+        this.cursorPosition = TerminalPosition.OF_0x0;
+        this.savedCursorPosition = TerminalPosition.OF_0x0;
         this.backlogSize = 1000;
     }
 
@@ -110,7 +110,7 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
     public synchronized void enterPrivateMode() {
         currentTextBuffer = privateModeTextBuffer;
         savedCursorPosition = getCursorBufferPosition();
-        setCursorPosition(TerminalPosition.TOP_LEFT_CORNER);
+        setCursorPosition(TerminalPosition.OF_0x0);
         setWholeBufferDirty();
     }
 
@@ -125,7 +125,7 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
     public synchronized void clearScreen() {
         currentTextBuffer.clear();
         setWholeBufferDirty();
-        setCursorPosition(TerminalPosition.TOP_LEFT_CORNER);
+        setCursorPosition(TerminalPosition.OF_0x0);
     }
 
     @Override
@@ -368,12 +368,12 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
             // Update the buffer
             int i = currentTextBuffer.setCharacter(cursorPosition.getRow(), cursorPosition.getColumn(), terminalCharacter);
             if(!wholeBufferDirty) {
-                dirtyTerminalCells.add(new TerminalPosition(cursorPosition.getColumn(), cursorPosition.getRow()));
+                dirtyTerminalCells.add(TerminalPosition.of(cursorPosition.getColumn(), cursorPosition.getRow()));
                 if(i == 1) {
-                    dirtyTerminalCells.add(new TerminalPosition(cursorPosition.getColumn() + 1, cursorPosition.getRow()));
+                    dirtyTerminalCells.add(TerminalPosition.of(cursorPosition.getColumn() + 1, cursorPosition.getRow()));
                 }
                 else if(i == 2) {
-                    dirtyTerminalCells.add(new TerminalPosition(cursorPosition.getColumn() - 1, cursorPosition.getRow()));
+                    dirtyTerminalCells.add(TerminalPosition.of(cursorPosition.getColumn() - 1, cursorPosition.getRow()));
                 }
                 if(dirtyTerminalCells.size() > (terminalSize.getColumns() * terminalSize.getRows() * 0.9)) {
                     setWholeBufferDirty();
@@ -440,7 +440,7 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
         this.cursorPosition = cursorPosition.withColumn(Math.min(cursorPosition.getColumn(), terminalSize.getColumns() - 1));
         this.cursorPosition = cursorPosition.withRow(Math.min(cursorPosition.getRow(), Math.max(terminalSize.getRows(), getBufferLineCount()) - 1));
         this.cursorPosition =
-                new TerminalPosition(
+                TerminalPosition.of(
                         Math.max(cursorPosition.getColumn(), 0),
                         Math.max(cursorPosition.getRow(), 0));
     }

--- a/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
@@ -58,7 +58,7 @@ public class DefaultVirtualTerminal extends AbstractTerminal implements VirtualT
      * Creates a new virtual terminal with an initial size set
      */
     public DefaultVirtualTerminal() {
-        this(new TerminalSize(80, 24));
+        this(TerminalSize.of(80, 24));
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/terminal/virtual/VirtualTerminalTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/virtual/VirtualTerminalTextGraphics.java
@@ -18,6 +18,7 @@
  */
 package com.googlecode.lanterna.terminal.virtual;
 
+import com.googlecode.lanterna.TerminalRectangle;
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.TextCharacter;
@@ -36,16 +37,14 @@ class VirtualTerminalTextGraphics extends AbstractTextGraphics {
     }
 
     @Override
-    public TextGraphics setCharacter(int columnIndex, int rowIndex, TextCharacter textCharacter) {
+    public TextGraphics setCharacter(int column, int row, TextCharacter textCharacter) {
         TerminalSize size = getSize();
-        if(columnIndex < 0 || columnIndex >= size.getColumns() ||
-                rowIndex < 0 || rowIndex >= size.getRows()) {
-            return this;
-        }
-        synchronized(virtualTerminal) {
-            virtualTerminal.setCursorPosition(new TerminalPosition(columnIndex, rowIndex));
-            virtualTerminal.putCharacter(textCharacter);
-        }
+        TerminalRectangle.whenContains(0, 0, size.columns, size.rows, column, row, () -> {
+            synchronized (virtualTerminal) {
+                virtualTerminal.setCursorPosition(TerminalPosition.of(column, row));
+                virtualTerminal.putCharacter(textCharacter);
+            }
+        });
         return this;
     }
 
@@ -56,7 +55,7 @@ class VirtualTerminalTextGraphics extends AbstractTextGraphics {
 
     @Override
     public TextCharacter getCharacter(int column, int row) {
-        return getCharacter(new TerminalPosition(column, row));
+        return getCharacter(TerminalPosition.of(column, row));
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/win32/WindowsTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/win32/WindowsTerminal.java
@@ -117,7 +117,7 @@ public class WindowsTerminal extends UnixLikeTerminal {
 		Wincon.INSTANCE.GetConsoleScreenBufferInfo(CONSOLE_OUTPUT.getHandle(), screenBufferInfo);
 		int columns = screenBufferInfo.srWindow.Right - screenBufferInfo.srWindow.Left + 1;
 		int rows = screenBufferInfo.srWindow.Bottom - screenBufferInfo.srWindow.Top + 1;
-		return new TerminalSize(columns, rows);
+		return TerminalSize.of(columns, rows);
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/lanterna/terminal/win32/WindowsTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/win32/WindowsTerminal.java
@@ -130,7 +130,7 @@ public class WindowsTerminal extends UnixLikeTerminal {
 		Wincon.INSTANCE.GetConsoleScreenBufferInfo(CONSOLE_OUTPUT.getHandle(), screenBufferInfo);
 		int column = screenBufferInfo.dwCursorPosition.X - screenBufferInfo.srWindow.Left;
 		int row = screenBufferInfo.dwCursorPosition.Y - screenBufferInfo.srWindow.Top;
-		return new TerminalPosition(column, row);
+		return TerminalPosition.of(column, row);
 	}
 
 	private int getConsoleInputMode() {

--- a/src/test/java/com/googlecode/lanterna/TestTerminalPosition.java
+++ b/src/test/java/com/googlecode/lanterna/TestTerminalPosition.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2020 Martin Berglund
+ */
+package com.googlecode.lanterna;
+
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author ginkoblongata
+ */
+public class TestTerminalPosition {
+
+    TerminalPosition tp(int x, int y) {
+        return TerminalPosition.of(x, y);
+    }
+    void assertSameSystemIdentityHashCode(Object a, Object b) {
+        assertEquals(System.identityHashCode(a), System.identityHashCode(b));
+    }
+    void assertNotSameSystemIdentityHashCode(Object a, Object b) {
+        assertNotEquals(System.identityHashCode(a), System.identityHashCode(b));
+    }
+    @Test
+    public void testSystemIdentityHashCodeSame() {
+        TerminalPosition a = TerminalPosition.of(23, 34);
+        assertSameSystemIdentityHashCode(a, a);
+    }
+    @Test
+    public void testSystemIdentityHashCodeDifferent() {
+        TerminalPosition a = TerminalPosition.of(23, 34);
+        TerminalPosition b = TerminalPosition.of(23, 34);
+        assertNotSameSystemIdentityHashCode(a, b);
+    }
+    @Test
+    public void testObjectChurnReduced_of() {
+        assertSameSystemIdentityHashCode(tp(0, 0), tp(0, 0));
+        assertSameSystemIdentityHashCode(TerminalPosition.OF_0x0, tp(0, 0));
+        assertSameSystemIdentityHashCode(TerminalPosition.OF_0x1, tp(0, 1));
+        assertSameSystemIdentityHashCode(TerminalPosition.OF_1x0, tp(1, 0));
+        assertSameSystemIdentityHashCode(TerminalPosition.OF_1x1, tp(1, 1));
+    }
+    @Test
+    public void testObjectChurnReduced_as() {
+        TerminalPosition p = tp(35, 80);
+        assertSameSystemIdentityHashCode(p, p.as(35, 80));
+    }
+    @Test
+    public void testObjectChurnReduced_plus() {
+        assertSameSystemIdentityHashCode(tp(0, 1), tp(0, 0).plus(0, 1));
+        assertSameSystemIdentityHashCode(tp(1, 1), tp(0, 0).plus(0 , 1).plus(1, 0));
+        assertSameSystemIdentityHashCode(tp(1, 1), tp(0, 0).plus(1 , 1));
+
+        TerminalPosition p = tp(35, 80);
+        assertSameSystemIdentityHashCode(p, p.plus(0, 0));
+    }
+    @Test
+    public void testObjectChurnReduced_minus() {
+        assertSameSystemIdentityHashCode(tp(0, 0), tp(1, 1).minus(1, 1));
+        assertSameSystemIdentityHashCode(tp(1, 1), tp(2, 2).minus(0, 1).minus(1, 0));
+
+        TerminalPosition p = tp(35, 80);
+        assertSameSystemIdentityHashCode(p, p.minus(0, 0));
+    }
+    @Test
+    public void testObjectChurnReduced_divide() {
+        TerminalPosition p = tp(35, 80);
+        assertSameSystemIdentityHashCode(p, p.divide(1, 1));
+    }
+    @Test
+    public void testObjectChurnReduced_multiply() {
+        TerminalPosition p = tp(35, 80);
+        assertSameSystemIdentityHashCode(p, p.multiply(1, 1));
+    }
+
+}

--- a/src/test/java/com/googlecode/lanterna/TestTerminalPosition.java
+++ b/src/test/java/com/googlecode/lanterna/TestTerminalPosition.java
@@ -20,6 +20,8 @@ package com.googlecode.lanterna;
 
 import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -36,6 +38,14 @@ public class TestTerminalPosition {
     }
     void assertNotSameSystemIdentityHashCode(Object a, Object b) {
         assertNotEquals(System.identityHashCode(a), System.identityHashCode(b));
+    }
+    
+    @Test
+    public void test_instantiation() {
+        assertTrue(tp(12, 14).getColumn() == 12);
+        assertTrue(tp(12, 14).getRow() == 14);
+        assertTrue(tp(12, 14).column == 12);
+        assertTrue(tp(12, 14).row == 14);
     }
     @Test
     public void testSystemIdentityHashCodeSame() {
@@ -58,8 +68,9 @@ public class TestTerminalPosition {
     }
     @Test
     public void testObjectChurnReduced_as() {
-        TerminalPosition p = tp(35, 80);
-        assertSameSystemIdentityHashCode(p, p.as(35, 80));
+        TerminalPosition p = tp(35, 40);
+        assertSameSystemIdentityHashCode(p, p.as(35, 40));
+        assertSameSystemIdentityHashCode(p, p.as(tp(35, 40)));
     }
     @Test
     public void testObjectChurnReduced_plus() {
@@ -67,7 +78,7 @@ public class TestTerminalPosition {
         assertSameSystemIdentityHashCode(tp(1, 1), tp(0, 0).plus(0 , 1).plus(1, 0));
         assertSameSystemIdentityHashCode(tp(1, 1), tp(0, 0).plus(1 , 1));
 
-        TerminalPosition p = tp(35, 80);
+        TerminalPosition p = tp(35, 40);
         assertSameSystemIdentityHashCode(p, p.plus(0, 0));
     }
     @Test
@@ -75,18 +86,168 @@ public class TestTerminalPosition {
         assertSameSystemIdentityHashCode(tp(0, 0), tp(1, 1).minus(1, 1));
         assertSameSystemIdentityHashCode(tp(1, 1), tp(2, 2).minus(0, 1).minus(1, 0));
 
-        TerminalPosition p = tp(35, 80);
+        TerminalPosition p = tp(35, 40);
         assertSameSystemIdentityHashCode(p, p.minus(0, 0));
     }
     @Test
     public void testObjectChurnReduced_divide() {
-        TerminalPosition p = tp(35, 80);
+        TerminalPosition p = tp(35, 40);
         assertSameSystemIdentityHashCode(p, p.divide(1, 1));
     }
     @Test
     public void testObjectChurnReduced_multiply() {
-        TerminalPosition p = tp(35, 80);
+        TerminalPosition p = tp(35, 40);
         assertSameSystemIdentityHashCode(p, p.multiply(1, 1));
+    }
+    // ------------------------------------------------------
+    
+    @Test
+    public void test_withColumn() {
+        TerminalPosition a = tp(35, 40);
+        assertTrue(a.getColumn() == 35);
+        assertTrue(a.withColumn(20).equals(20, 40));
+    }
+    @Test
+    public void test_withRow() {
+        TerminalPosition a = tp(35, 40);
+        assertTrue(a.getRow() == 40);
+        assertTrue(a.withRow(15).equals(35, 15));
+    }
+    @Test
+    public void test_withRelativeColumn() {
+        TerminalPosition a = tp(35, 40);
+        assertTrue(a.getColumn() == 35);
+        assertTrue(a.withRelativeColumn(5).equals(40, 40));
+    }
+    @Test
+    public void test_withRelativeRow() {
+        TerminalPosition a = tp(35, 40);
+        assertTrue(a.getRow() == 40);
+        assertTrue(a.withRelativeRow(-21).equals(35, 19));
+    }
+    
+    @Test
+    public void test_withRelative() {
+        assertTrue(tp(33, 40).withRelative(tp(2, 3)).equals(35, 43));
+        assertTrue(tp(33, 40).withRelative(tp(-2, -3)).equals(31, 37));
+        assertTrue(tp(33, 40).withRelative(2, 3).equals(35, 43));
+        assertTrue(tp(33, 40).withRelative(-2, -3).equals(31, 37));
+    }
+    
+    @Test
+    public void testObjectChurnReduced_with() {
+        TerminalPosition p = tp(35, 40);
+        assertSameSystemIdentityHashCode(p, p.with(p));
+    }
+    
+    @Test
+    public void test_plus() {
+        assertTrue(tp(3, 5).plus(2).equals(5, 7));
+        assertTrue(tp(0, 0).plus(1).equals(1, 1));
+        assertTrue(tp(3, 2).plus(0).equals(3, 2));
+        assertTrue(tp(3, 5).plus(-1).equals(2, 4));
+        assertTrue(tp(3, 5).plus(-2).equals(1, 3));
+        
+        assertTrue(tp(11, 22).plus(3, 5).equals(14, 27));
+        assertTrue(tp(0, 0).plus(1, 2).equals(1, 2));
+        assertTrue(tp(3, 5).plus(-4, 3).equals(-1, 8));
+        assertTrue(tp(3, 5).plus(0, 5).equals(3, 10));
+        
+        assertTrue(tp(11, 22).plus(tp(3, 5)).equals(14, 27));
+        assertTrue(tp(0, 0).plus(tp(1, 2)).equals(1, 2));
+        assertTrue(tp(3, 5).plus(tp(-4, 3)).equals(-1, 8));
+        assertTrue(tp(3, 5).plus(tp(0, 5)).equals(3, 10));
+    }
+    @Test
+    public void test_minus() {
+        assertTrue(tp(3, 5).minus(2).equals(1, 3));
+        assertTrue(tp(0, 0).minus(1).equals(-1, -1));
+        assertTrue(tp(3, 2).minus(0).equals(3, 2));
+        assertTrue(tp(3, 5).minus(-1).equals(4, 6));
+        assertTrue(tp(3, 5).minus(-2).equals(5, 7));
+
+        assertTrue(tp(11, 22).minus(3, 2).equals(8, 20));
+        assertTrue(tp(11, 22).minus(-3, -2).equals(14, 24));
+        assertTrue(tp(11, 22).minus(0, 5).equals(11, 17));
+        assertTrue(tp(11, 22).minus(1, 0).equals(10, 22));
+        
+        assertTrue(tp(11, 22).minus(tp(3, 2)).equals(8, 20));
+        assertTrue(tp(11, 22).minus(tp(-3, -2)).equals(14, 24));
+        assertTrue(tp(11, 22).minus(tp(0, 5)).equals(11, 17));
+        assertTrue(tp(11, 22).minus(tp(1, 0)).equals(10, 22));
+    }
+    @Test
+    public void test_multiply() {
+        assertTrue(tp(11, 22).multiply(-3).equals(-33, -66));
+        assertTrue(tp(11, 22).multiply(-1).equals(-11, -22));
+        assertTrue(tp(11, 22).multiply(-0).equals(0, 0));
+        assertTrue(tp(11, 22).multiply(0).equals(0, 0));
+        assertTrue(tp(11, 22).multiply(1).equals(11, 22));
+        assertTrue(tp(11, 22).multiply(3).equals(33, 66));
+        
+        assertTrue(tp(11, 22).multiply(1, 2).equals(11, 44));
+        assertTrue(tp(11, 22).multiply(-3, -2).equals(-33, -44));
+        assertTrue(tp(11, 22).multiply(0, 5).equals(0, 110));
+        assertTrue(tp(11, 22).multiply(1, 0).equals(11, 0));
+        
+        assertTrue(tp(11, 22).multiply(1, 2).equals(11, 44));
+        assertTrue(tp(11, 22).multiply(-3, -2).equals(-33, -44));
+        assertTrue(tp(11, 22).multiply(0, 5).equals(0, 110));
+        assertTrue(tp(11, 22).multiply(1, 0).equals(11, 0));
+    }
+    @Test
+    public void test_divide() {
+        assertTrue(tp(11, 22).divide(1, 2).equals(11, 11));
+        assertTrue(tp(11, 22).divide(1, 5).equals(11, 4));
+        assertTrue(tp(20, 22).divide(4, 1).equals(5, 22));
+        assertTrue(tp(20, 30).divide(1, 4).equals(20, 7));
+    }
+    @Test
+    public void test_abs() {
+        assertTrue(tp(-5, 7).abs().equals(5, 7));
+        assertTrue(tp(-7, -9).abs().equals(7, 9));
+        assertTrue(tp(11, -11).abs().equals(11, 11));
+    }
+    @Test
+    public void test_min() {
+        assertTrue(tp(5, 8).min(tp(9, 7)).equals(5, 7));
+        assertTrue(tp(5, 8).min(tp(4, 9)).equals(4, 8));
+        assertTrue(tp(0, 0).min(tp(-4, 9)).equals(-4, 0));
+    }
+    @Test
+    public void test_max() {
+        assertTrue(tp(5, 8).min(tp(9, 7)).equals(5, 7));
+        assertTrue(tp(5, 8).min(tp(4, 9)).equals(4, 8));
+        assertTrue(tp(0, 0).min(tp(4, 9)).equals(0, 0));
+    }
+    @Test
+    public void test_compareTo() {
+        assertTrue(tp(5, 6).compareTo(tp(5, 7)) < 0);
+        assertTrue(tp(5, 6).compareTo(tp(5, 6)) == 0);
+        assertTrue(tp(5, 6).compareTo(tp(5, 5)) > 0);
+        
+        assertTrue(tp(5, 6).compareTo(tp(6, 6)) < 0);
+        assertTrue(tp(5, 6).compareTo(tp(5, 6)) == 0);
+        assertTrue(tp(5, 6).compareTo(tp(4, 6)) > 0);
+    }
+    @Test
+    public void test_hashCode() {
+        TerminalPosition a = tp(7, 7);
+        TerminalPosition b = tp(7, 7);
+        assertNotSameSystemIdentityHashCode(a, b);
+        assertTrue(a.hashCode() == b.hashCode());
+        assertFalse(tp(7, 7).hashCode() == tp(3, 7).hashCode());
+    }
+    @Test
+    public void test_equals() {
+        TerminalPosition a = tp(8, 9);
+        TerminalPosition b = tp(8, 9);
+        assertNotSameSystemIdentityHashCode(a, b);
+        assertTrue(a.equals(b));
+        assertTrue(a.equals(8, 9));
+        TerminalPosition c = tp(4, 9);
+        assertFalse(c.equals(a));
+        assertFalse(c.equals(5, 9));
     }
 
 }

--- a/src/test/java/com/googlecode/lanterna/TestTerminalSize.java
+++ b/src/test/java/com/googlecode/lanterna/TestTerminalSize.java
@@ -1,0 +1,241 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2020 Martin Berglund
+ */
+package com.googlecode.lanterna;
+
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author ginkoblongata
+ */
+public class TestTerminalSize {
+
+    TerminalSize ts(int x, int y) {
+        return TerminalSize.of(x, y);
+    }
+    void assertSameSystemIdentityHashCode(Object a, Object b) {
+        assertEquals(System.identityHashCode(a), System.identityHashCode(b));
+    }
+    void assertNotSameSystemIdentityHashCode(Object a, Object b) {
+        assertNotEquals(System.identityHashCode(a), System.identityHashCode(b));
+    }
+    
+    @Test
+    public void test_instantiation() {
+        assertTrue(ts(12, 14).getColumns() == 12);
+        assertTrue(ts(12, 14).getRows() == 14);
+        assertTrue(ts(12, 14).columns == 12);
+        assertTrue(ts(12, 14).rows == 14);
+    }
+    @Test
+    public void testSystemIdentityHashCodeSame() {
+        TerminalSize a = TerminalSize.of(23, 34);
+        assertSameSystemIdentityHashCode(a, a);
+    }
+    @Test
+    public void testSystemIdentityHashCodeDifferent() {
+        TerminalSize a = TerminalSize.of(23, 34);
+        TerminalSize b = TerminalSize.of(23, 34);
+        assertNotSameSystemIdentityHashCode(a, b);
+    }
+    @Test
+    public void testObjectChurnReduced_of() {
+        assertSameSystemIdentityHashCode(ts(0, 0), ts(0, 0));
+        assertSameSystemIdentityHashCode(TerminalSize.OF_0x0, ts(0, 0));
+        assertSameSystemIdentityHashCode(TerminalSize.OF_0x1, ts(0, 1));
+        assertSameSystemIdentityHashCode(TerminalSize.OF_1x0, ts(1, 0));
+        assertSameSystemIdentityHashCode(TerminalSize.OF_1x1, ts(1, 1));
+    }
+    @Test
+    public void testObjectChurnReduced_as() {
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.as(35, 40));
+        assertSameSystemIdentityHashCode(p, p.as(ts(35, 40)));
+    }
+    @Test
+    public void testObjectChurnReduced_plus() {
+        assertSameSystemIdentityHashCode(ts(0, 1), ts(0, 0).plus(0, 1));
+        assertSameSystemIdentityHashCode(ts(1, 1), ts(0, 0).plus(0 , 1).plus(1, 0));
+        assertSameSystemIdentityHashCode(ts(1, 1), ts(0, 0).plus(1 , 1));
+
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.plus(0, 0));
+    }
+    @Test
+    public void testObjectChurnReduced_minus() {
+        assertSameSystemIdentityHashCode(ts(0, 0), ts(1, 1).minus(1, 1));
+        assertSameSystemIdentityHashCode(ts(1, 1), ts(2, 2).minus(0, 1).minus(1, 0));
+
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.minus(0, 0));
+    }
+    @Test
+    public void testObjectChurnReduced_divide() {
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.divide(1, 1));
+    }
+    @Test
+    public void testObjectChurnReduced_multiply() {
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.multiply(1, 1));
+    }
+    // ------------------------------------------------------
+    
+    @Test
+    public void test_withColumn() {
+        TerminalSize a = ts(35, 40);
+        assertTrue(a.getColumns() == 35);
+        assertTrue(a.withColumns(20).equals(20, 40));
+    }
+    @Test
+    public void test_withRow() {
+        TerminalSize a = ts(35, 40);
+        assertTrue(a.getRows() == 40);
+        assertTrue(a.withRows(15).equals(35, 15));
+    }
+    @Test
+    public void test_withRelativeColumn() {
+        TerminalSize a = ts(35, 40);
+        assertTrue(a.getColumns() == 35);
+        assertTrue(a.withRelativeColumns(5).equals(40, 40));
+    }
+    @Test
+    public void test_withRelativeRow() {
+        TerminalSize a = ts(35, 40);
+        assertTrue(a.getRows() == 40);
+        assertTrue(a.withRelativeRows(-21).equals(35, 19));
+    }
+    
+    @Test
+    public void test_withRelative() {
+        assertTrue(ts(33, 40).withRelative(ts(2, 3)).equals(35, 43));
+        
+        assertTrue(ts(33, 40).withRelative(2, 3).equals(35, 43));
+        assertTrue(ts(33, 40).withRelative(-2, -3).equals(31, 37));
+    }
+    
+    @Test
+    public void testObjectChurnReduced_with() {
+        TerminalSize p = ts(35, 40);
+        assertSameSystemIdentityHashCode(p, p.with(p));
+    }
+    
+    @Test
+    public void test_plus() {
+        assertTrue(ts(3, 5).plus(2).equals(5, 7));
+        assertTrue(ts(0, 0).plus(1).equals(1, 1));
+        assertTrue(ts(3, 2).plus(0).equals(3, 2));
+        assertTrue(ts(3, 5).plus(-1).equals(2, 4));
+        assertTrue(ts(3, 5).plus(-2).equals(1, 3));
+        
+        assertTrue(ts(11, 22).plus(3, 5).equals(14, 27));
+        assertTrue(ts(0, 0).plus(1, 2).equals(1, 2));
+        assertTrue(ts(3, 5).plus(-3, 3).equals(0, 8));
+        assertTrue(ts(3, 5).plus(0, 5).equals(3, 10));
+        
+        assertTrue(ts(11, 22).plus(ts(3, 5)).equals(14, 27));
+        assertTrue(ts(0, 0).plus(ts(1, 2)).equals(1, 2));
+        assertTrue(ts(3, 5).plus(ts(3, 3)).equals(6, 8));
+        assertTrue(ts(3, 5).plus(ts(0, 5)).equals(3, 10));
+    }
+    @Test
+    public void test_minus() {
+        assertTrue(ts(3, 5).minus(2).equals(1, 3));
+        assertTrue(ts(3, 2).minus(0).equals(3, 2));
+        assertTrue(ts(3, 5).minus(-1).equals(4, 6));
+        assertTrue(ts(3, 5).minus(-2).equals(5, 7));
+
+        assertTrue(ts(11, 22).minus(3, 2).equals(8, 20));
+        assertTrue(ts(11, 22).minus(-3, -2).equals(14, 24));
+        assertTrue(ts(11, 22).minus(0, 5).equals(11, 17));
+        assertTrue(ts(11, 22).minus(1, 0).equals(10, 22));
+        
+        assertTrue(ts(11, 22).minus(ts(3, 2)).equals(8, 20));
+        assertTrue(ts(11, 22).minus(ts(0, 5)).equals(11, 17));
+        assertTrue(ts(11, 22).minus(ts(1, 0)).equals(10, 22));
+    }
+    @Test
+    public void test_multiply() {
+        assertTrue(ts(11, 22).multiply(0).equals(0, 0));
+        assertTrue(ts(11, 22).multiply(-0).equals(0, 0));
+        assertTrue(ts(11, 22).multiply(0).equals(0, 0));
+        assertTrue(ts(11, 22).multiply(1).equals(11, 22));
+        assertTrue(ts(11, 22).multiply(3).equals(33, 66));
+        
+        assertTrue(ts(11, 22).multiply(1, 2).equals(11, 44));
+        assertTrue(ts(11, 22).multiply(0, 5).equals(0, 110));
+        assertTrue(ts(11, 22).multiply(1, 0).equals(11, 0));
+        
+        assertTrue(ts(11, 22).multiply(ts(1, 2)).equals(11, 44));
+        assertTrue(ts(11, 22).multiply(ts(0, 5)).equals(0, 110));
+        assertTrue(ts(11, 22).multiply(ts(1, 0)).equals(11, 0));
+    }
+    @Test
+    public void test_divide() {
+        assertTrue(ts(11, 22).divide(1, 2).equals(11, 11));
+        assertTrue(ts(11, 22).divide(1, 5).equals(11, 4));
+        assertTrue(ts(20, 22).divide(4, 1).equals(5, 22));
+        assertTrue(ts(20, 30).divide(1, 4).equals(20, 7));
+    }
+    @Test
+    public void test_min() {
+        assertTrue(ts(5, 8).min(ts(9, 7)).equals(5, 7));
+        assertTrue(ts(5, 8).min(ts(4, 9)).equals(4, 8));
+    }
+    @Test
+    public void test_max() {
+        assertTrue(ts(5, 8).min(ts(9, 7)).equals(5, 7));
+        assertTrue(ts(5, 8).min(ts(4, 9)).equals(4, 8));
+        assertTrue(ts(0, 0).min(ts(4, 9)).equals(0, 0));
+    }
+    @Test
+    public void test_compareTo() {
+        assertTrue(ts(5, 6).compareTo(ts(5, 7)) < 0);
+        assertTrue(ts(5, 6).compareTo(ts(5, 6)) == 0);
+        assertTrue(ts(5, 6).compareTo(ts(5, 5)) > 0);
+        
+        assertTrue(ts(5, 6).compareTo(ts(6, 6)) < 0);
+        assertTrue(ts(5, 6).compareTo(ts(5, 6)) == 0);
+        assertTrue(ts(5, 6).compareTo(ts(4, 6)) > 0);
+    }
+    @Test
+    public void test_hashCode() {
+        TerminalSize a = ts(7, 7);
+        TerminalSize b = ts(7, 7);
+        assertNotSameSystemIdentityHashCode(a, b);
+        assertTrue(a.hashCode() == b.hashCode());
+        assertFalse(ts(7, 7).hashCode() == ts(3, 7).hashCode());
+    }
+    @Test
+    public void test_equals() {
+        TerminalSize a = ts(8, 9);
+        TerminalSize b = ts(8, 9);
+        assertNotSameSystemIdentityHashCode(a, b);
+        assertTrue(a.equals(b));
+        assertTrue(a.equals(8, 9));
+        TerminalSize c = ts(4, 9);
+        assertFalse(c.equals(a));
+        assertFalse(c.equals(5, 9));
+    }
+
+}

--- a/src/test/java/com/googlecode/lanterna/gui2/ComboBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ComboBoxTest.java
@@ -59,7 +59,7 @@ public class ComboBoxTest extends TestBase {
                 comboBoxReadOnly.withBorder(Borders.singleLine("Read-only")),
                 comboBoxEditable.withBorder(Borders.singleLine("Editable")),
                 comboBoxCJK.withBorder(Borders.singleLine("CJK"))));
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
 
         final TextBox textBoxNewItem = new TextBox(new TerminalSize(20, 1));
         Button buttonAddItem = new Button("Add", () -> {
@@ -96,9 +96,9 @@ public class ComboBoxTest extends TestBase {
                         Panels.horizontal(textBoxSetSelectedItem, buttonSetSelectedItem))
                     .withBorder(Borders.singleLineBevel("Modify Content")));
 
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         mainPanel.addComponent(comboBoxTimeZones.withBorder(Borders.singleLine("Large ComboBox")));
-        mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         mainPanel.addComponent(new Separator(Direction.HORIZONTAL).setLayoutData(LinearLayout.createLayoutData(LinearLayout.Alignment.FILL)));
         mainPanel.addComponent(new Button("OK", window::close));
         window.setComponent(mainPanel);

--- a/src/test/java/com/googlecode/lanterna/gui2/ComboBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ComboBoxTest.java
@@ -53,7 +53,7 @@ public class ComboBoxTest extends TestBase {
         comboBoxCJK.addItem("ウィキペディアは誰でも編集できるフリー百科事典です");
         comboBoxCJK.addItem("위키백과는 전 세계 여러 언어로 만들어 나가는 자유 백과사전으로, 누구나 참여하실 수 있습니다.");
         comboBoxCJK.addItem("This is a string without double-width characters");
-        comboBoxCJK.setPreferredSize(new TerminalSize(13, 1));
+        comboBoxCJK.setPreferredSize(TerminalSize.of(13, 1));
 
         mainPanel.addComponent(Panels.horizontal(
                 comboBoxReadOnly.withBorder(Borders.singleLine("Read-only")),
@@ -61,14 +61,14 @@ public class ComboBoxTest extends TestBase {
                 comboBoxCJK.withBorder(Borders.singleLine("CJK"))));
         mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
 
-        final TextBox textBoxNewItem = new TextBox(new TerminalSize(20, 1));
+        final TextBox textBoxNewItem = new TextBox(TerminalSize.of(20, 1));
         Button buttonAddItem = new Button("Add", () -> {
             comboBoxEditable.addItem(textBoxNewItem.getText());
             comboBoxReadOnly.addItem(textBoxNewItem.getText());
             textBoxNewItem.setText("");
             window.setFocusedInteractable(textBoxNewItem);
         });
-        final TextBox textBoxSetSelectedIndex = new TextBox(new TerminalSize(20, 1), "0");
+        final TextBox textBoxSetSelectedIndex = new TextBox(TerminalSize.of(20, 1), "0");
         textBoxSetSelectedIndex.setValidationPattern(Pattern.compile("-?[0-9]+"));
         Button buttonSetSelectedIndex = new Button("Set Selected Index", () -> {
             try {
@@ -79,7 +79,7 @@ public class ComboBoxTest extends TestBase {
                 MessageDialog.showMessageDialog(textGUI, e.getClass().getName(), e.getMessage(), MessageDialogButton.OK);
             }
         });
-        final TextBox textBoxSetSelectedItem = new TextBox(new TerminalSize(20, 1));
+        final TextBox textBoxSetSelectedItem = new TextBox(TerminalSize.of(20, 1));
         Button buttonSetSelectedItem = new Button("Set Selected Item", () -> {
             try {
                 comboBoxEditable.setSelectedItem(textBoxSetSelectedItem.getText());

--- a/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
@@ -52,7 +52,7 @@ public class DialogsTextGUIBasicTest {
             dialogsListBox.addItem("Multi-line input", () -> {
                 String result = new TextInputDialogBuilder()
                         .setTitle("Multi-line editor")
-                        .setTextBoxSize(new TerminalSize(35, 5))
+                        .setTextBoxSize(TerminalSize.of(35, 5))
                         .build()
                         .showDialog(textGUI);
                 System.out.println("Result was: " + result);

--- a/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
@@ -94,7 +94,7 @@ public class DialogsTextGUIBasicTest {
                     .showDialog(textGUI));
 
             mainPanel.addComponent(dialogsListBox);
-            mainPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+            mainPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
             mainPanel.addComponent(new Button("Exit", window::close));
             window.setComponent(mainPanel);
 

--- a/src/test/java/com/googlecode/lanterna/gui2/DynamicGridLayoutTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/DynamicGridLayoutTest.java
@@ -208,11 +208,11 @@ public class DynamicGridLayoutTest extends TestBase {
             contentPane.addComponent(textBoxBottomMargin);
 
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
             contentPane.addComponent(
                     new Separator(Direction.HORIZONTAL).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
 
             Button okButton = new Button("OK", () -> {
                 gridLayout.setHorizontalSpacing(Integer.parseInt(textBoxHorizontalSpacing.getTextOrDefault("0")));
@@ -255,7 +255,7 @@ public class DynamicGridLayoutTest extends TestBase {
             contentPane.addComponent(radioBoxesHorizontalAlignment);
 
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
 
             contentPane.addComponent(new Label("Vertical alignment:"));
             final RadioBoxList<GridLayout.Alignment> radioBoxesVerticalAlignment = new RadioBoxList<>();
@@ -267,7 +267,7 @@ public class DynamicGridLayoutTest extends TestBase {
             contentPane.addComponent(radioBoxesVerticalAlignment);
 
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
 
             contentPane.addComponent(new Label("Grab extra horizontal space:"));
             final CheckBox checkBoxGrabExtraHorizontalSpace = new CheckBox("");
@@ -280,7 +280,7 @@ public class DynamicGridLayoutTest extends TestBase {
             contentPane.addComponent(checkBoxGrabExtraVerticalSpace);
 
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
 
             Pattern numberPattern = Pattern.compile("[1-9][0-9]*");
 
@@ -295,11 +295,11 @@ public class DynamicGridLayoutTest extends TestBase {
             contentPane.addComponent(textBoxVerticalSpan);
 
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
             contentPane.addComponent(
                     new Separator(Direction.HORIZONTAL).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
             contentPane.addComponent(
-                    new EmptySpace(TerminalSize.ONE).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
+                    new EmptySpace(TerminalSize.OF_1x1).setLayoutData(GridLayout.createHorizontallyFilledLayoutData(2)));
 
             Button okButton = new Button("OK", () -> {
                 component.setLayoutData(

--- a/src/test/java/com/googlecode/lanterna/gui2/DynamicGridLayoutTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/DynamicGridLayoutTest.java
@@ -53,7 +53,7 @@ public class DynamicGridLayoutTest extends TestBase {
         gridPanel.setLayoutManager(gridLayout);
 
         for(int i = 0; i < 16; i++) {
-            gridPanel.addComponent(new EmptySpace(getRandomColor(), new TerminalSize(4, 1)));
+            gridPanel.addComponent(new EmptySpace(getRandomColor(), TerminalSize.of(4, 1)));
         }
 
         Panel controlPanel = new Panel();
@@ -103,7 +103,7 @@ public class DynamicGridLayoutTest extends TestBase {
                 if(sizeString == null) {
                     return;
                 }
-                TerminalSize size = new TerminalSize(Integer.parseInt(sizeString.split("x")[0]), Integer.parseInt(sizeString.split("x")[1]));
+                TerminalSize size = TerminalSize.of(Integer.parseInt(sizeString.split("x")[0]), Integer.parseInt(sizeString.split("x")[1]));
                 component = componentType == SelectableComponentType.Block ? new EmptySpace(getRandomColor(), size) : new TextBox(size);
                 break;
 
@@ -141,7 +141,7 @@ public class DynamicGridLayoutTest extends TestBase {
         gridPanel.setLayoutManager(newGridLayout(columns.intValue()));
         //noinspection ConstantConditions
         for(int i = 0; i < prepopulate.intValue(); i++) {
-            gridPanel.addComponent(new EmptySpace(getRandomColor(), new TerminalSize(4, 1)));
+            gridPanel.addComponent(new EmptySpace(getRandomColor(), TerminalSize.of(4, 1)));
         }
     }
 
@@ -285,12 +285,12 @@ public class DynamicGridLayoutTest extends TestBase {
             Pattern numberPattern = Pattern.compile("[1-9][0-9]*");
 
             contentPane.addComponent(new Label("Horizontal span:"));
-            final TextBox textBoxHorizontalSpan = new TextBox(new TerminalSize(5, 1), gridLayoutData.horizontalSpan + "");
+            final TextBox textBoxHorizontalSpan = new TextBox(TerminalSize.of(5, 1), gridLayoutData.horizontalSpan + "");
             textBoxHorizontalSpan.setValidationPattern(numberPattern);
             contentPane.addComponent(textBoxHorizontalSpan);
 
             contentPane.addComponent(new Label("Vertical span:"));
-            final TextBox textBoxVerticalSpan = new TextBox(new TerminalSize(5, 1), gridLayoutData.verticalSpan + "");
+            final TextBox textBoxVerticalSpan = new TextBox(TerminalSize.of(5, 1), gridLayoutData.verticalSpan + "");
             textBoxVerticalSpan.setValidationPattern(numberPattern);
             contentPane.addComponent(textBoxVerticalSpan);
 

--- a/src/test/java/com/googlecode/lanterna/gui2/FullScreenTextGUITest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/FullScreenTextGUITest.java
@@ -90,36 +90,36 @@ public class FullScreenTextGUITest {
             BIOSButton button14 = new BIOSButton("Exit Without Saving", "僕の事が思い出せなくても泣かないでね");
             
             button1.setSize(new TerminalSize(35, 1));
-            button1.setPosition(new TerminalPosition(3, 3));
+            button1.setPosition(TerminalPosition.of(3, 3));
             button2.setSize(new TerminalSize(35, 1));
-            button2.setPosition(new TerminalPosition(3, 5));
+            button2.setPosition(TerminalPosition.of(3, 5));
             button3.setSize(new TerminalSize(35, 1));
-            button3.setPosition(new TerminalPosition(3, 7));
+            button3.setPosition(TerminalPosition.of(3, 7));
             button4.setSize(new TerminalSize(35, 1));
-            button4.setPosition(new TerminalPosition(3, 9));
+            button4.setPosition(TerminalPosition.of(3, 9));
             button5.setSize(new TerminalSize(35, 1));
-            button5.setPosition(new TerminalPosition(3, 11));
+            button5.setPosition(TerminalPosition.of(3, 11));
             button6.setSize(new TerminalSize(35, 1));
-            button6.setPosition(new TerminalPosition(3, 13));
+            button6.setPosition(TerminalPosition.of(3, 13));
             button7.setSize(new TerminalSize(35, 1));
-            button7.setPosition(new TerminalPosition(3, 15));
+            button7.setPosition(TerminalPosition.of(3, 15));
             
             button8.setSize(new TerminalSize(35, 1));
-            button8.setPosition(new TerminalPosition(43, 3));
+            button8.setPosition(TerminalPosition.of(43, 3));
             button9.setSize(new TerminalSize(35, 1));
-            button9.setPosition(new TerminalPosition(43, 5));
+            button9.setPosition(TerminalPosition.of(43, 5));
             button10.setSize(new TerminalSize(35, 1));
-            button10.setPosition(new TerminalPosition(43, 7));
+            button10.setPosition(TerminalPosition.of(43, 7));
             button11.setSize(new TerminalSize(35, 1));
-            button11.setPosition(new TerminalPosition(43, 9));
+            button11.setPosition(TerminalPosition.of(43, 9));
             button12.setSize(new TerminalSize(35, 1));
-            button12.setPosition(new TerminalPosition(43, 11));
+            button12.setPosition(TerminalPosition.of(43, 11));
             button13.setSize(new TerminalSize(35, 1));
-            button13.setPosition(new TerminalPosition(43, 13));
+            button13.setPosition(TerminalPosition.of(43, 13));
             button14.setSize(new TerminalSize(35, 1));
-            button14.setPosition(new TerminalPosition(43, 15));
+            button14.setPosition(TerminalPosition.of(43, 15));
             
-            helpLabel.setPosition(new TerminalPosition(2, 22));
+            helpLabel.setPosition(TerminalPosition.of(2, 22));
             helpLabel.setSize(new TerminalSize(76, 1));
             addComponent(helpLabel);
             for(BIOSButton button: Arrays.asList(button1, button2, button3, button4, button5, button6, button7, button8, button9, button10, button11, button12, button13, button14)) {
@@ -184,7 +184,7 @@ public class FullScreenTextGUITest {
                     graphics.setBackgroundColor(TextColor.ANSI.BLACK).fill(' ');
                     
                     //Draw the background image
-                    graphics.drawImage(TerminalPosition.TOP_LEFT_CORNER, background);
+                    graphics.drawImage(TerminalPosition.OF_0x0, background);
                     
                     //Then draw all the child components
                     panelRenderer.drawComponent(graphics, BIOS.this);

--- a/src/test/java/com/googlecode/lanterna/gui2/FullScreenTextGUITest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/FullScreenTextGUITest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FullScreenTextGUITest {
     public static void main(String[] args) throws IOException, InterruptedException {
-        Screen screen = new TestTerminalFactory(args).setInitialTerminalSize(new TerminalSize(80, 25)).createScreen();
+        Screen screen = new TestTerminalFactory(args).setInitialTerminalSize(TerminalSize.of(80, 25)).createScreen();
         screen.startScreen();
 
         final AtomicBoolean stop = new AtomicBoolean(false);
@@ -89,38 +89,38 @@ public class FullScreenTextGUITest {
             BIOSButton button13 = new BIOSButton("Save & Exit Setup", "...and then you can have some cake!");
             BIOSButton button14 = new BIOSButton("Exit Without Saving", "僕の事が思い出せなくても泣かないでね");
             
-            button1.setSize(new TerminalSize(35, 1));
+            button1.setSize(TerminalSize.of(35, 1));
             button1.setPosition(TerminalPosition.of(3, 3));
-            button2.setSize(new TerminalSize(35, 1));
+            button2.setSize(TerminalSize.of(35, 1));
             button2.setPosition(TerminalPosition.of(3, 5));
-            button3.setSize(new TerminalSize(35, 1));
+            button3.setSize(TerminalSize.of(35, 1));
             button3.setPosition(TerminalPosition.of(3, 7));
-            button4.setSize(new TerminalSize(35, 1));
+            button4.setSize(TerminalSize.of(35, 1));
             button4.setPosition(TerminalPosition.of(3, 9));
-            button5.setSize(new TerminalSize(35, 1));
+            button5.setSize(TerminalSize.of(35, 1));
             button5.setPosition(TerminalPosition.of(3, 11));
-            button6.setSize(new TerminalSize(35, 1));
+            button6.setSize(TerminalSize.of(35, 1));
             button6.setPosition(TerminalPosition.of(3, 13));
-            button7.setSize(new TerminalSize(35, 1));
+            button7.setSize(TerminalSize.of(35, 1));
             button7.setPosition(TerminalPosition.of(3, 15));
             
-            button8.setSize(new TerminalSize(35, 1));
+            button8.setSize(TerminalSize.of(35, 1));
             button8.setPosition(TerminalPosition.of(43, 3));
-            button9.setSize(new TerminalSize(35, 1));
+            button9.setSize(TerminalSize.of(35, 1));
             button9.setPosition(TerminalPosition.of(43, 5));
-            button10.setSize(new TerminalSize(35, 1));
+            button10.setSize(TerminalSize.of(35, 1));
             button10.setPosition(TerminalPosition.of(43, 7));
-            button11.setSize(new TerminalSize(35, 1));
+            button11.setSize(TerminalSize.of(35, 1));
             button11.setPosition(TerminalPosition.of(43, 9));
-            button12.setSize(new TerminalSize(35, 1));
+            button12.setSize(TerminalSize.of(35, 1));
             button12.setPosition(TerminalPosition.of(43, 11));
-            button13.setSize(new TerminalSize(35, 1));
+            button13.setSize(TerminalSize.of(35, 1));
             button13.setPosition(TerminalPosition.of(43, 13));
-            button14.setSize(new TerminalSize(35, 1));
+            button14.setSize(TerminalSize.of(35, 1));
             button14.setPosition(TerminalPosition.of(43, 15));
             
             helpLabel.setPosition(TerminalPosition.of(2, 22));
-            helpLabel.setSize(new TerminalSize(76, 1));
+            helpLabel.setSize(TerminalSize.of(76, 1));
             addComponent(helpLabel);
             for(BIOSButton button: Arrays.asList(button1, button2, button3, button4, button5, button6, button7, button8, button9, button10, button11, button12, button13, button14)) {
                 addComponent(button);
@@ -175,7 +175,7 @@ public class FullScreenTextGUITest {
             return new ComponentRenderer<Panel>() {
                 @Override
                 public TerminalSize getPreferredSize(Panel component) {
-                    return new TerminalSize(80, 24);
+                    return TerminalSize.of(80, 24);
                 }
 
                 @Override
@@ -215,7 +215,7 @@ public class FullScreenTextGUITest {
 
                     @Override
                     public TerminalSize getPreferredSize(Button component) {
-                        return new TerminalSize(TerminalTextUtils.getColumnWidth(getLabel()), 1);
+                        return TerminalSize.of(TerminalTextUtils.getColumnWidth(getLabel()), 1);
                     }
 
                     @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/GUIOverTelnet.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/GUIOverTelnet.java
@@ -78,7 +78,7 @@ public class GUIOverTelnet {
             }).withBorder(Borders.singleLine("This is a button")));
 
 
-            final TextBox textBox = new TextBox(new TerminalSize(20, 4)) {
+            final TextBox textBox = new TextBox(TerminalSize.of(20, 4)) {
                 @Override
                 public Result handleKeyStroke(KeyStroke keyStroke) {
                     try {
@@ -102,7 +102,7 @@ public class GUIOverTelnet {
                     return new InteractableRenderer() {
                         @Override
                         public TerminalSize getPreferredSize(Component component) {
-                            return new TerminalSize(30, 1);
+                            return TerminalSize.of(30, 1);
                         }
 
                         @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/GUIOverTelnet.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/GUIOverTelnet.java
@@ -112,7 +112,7 @@ public class GUIOverTelnet {
 
                         @Override
                         public TerminalPosition getCursorLocation(Component component) {
-                            return TerminalPosition.TOP_LEFT_CORNER;
+                            return TerminalPosition.OF_0x0;
                         }
                     };
                 }

--- a/src/test/java/com/googlecode/lanterna/gui2/GridLayoutTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/GridLayoutTest.java
@@ -66,8 +66,8 @@ public class GridLayoutTest extends TestBase {
 
         Panel contentPanel = new Panel();
         contentPanel.setLayoutManager(new LinearLayout(Direction.VERTICAL));
-        contentPanel.addComponent(Panels.horizontal(leftGridPanel, new EmptySpace(TerminalSize.ONE), rightGridPanel));
-        contentPanel.addComponent(new EmptySpace(TerminalSize.ONE));
+        contentPanel.addComponent(Panels.horizontal(leftGridPanel, new EmptySpace(TerminalSize.OF_1x1), rightGridPanel));
+        contentPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         contentPanel.addComponent(Panels.horizontal(
                 new Button("Toggle Visible Component", () -> visibilityToggleableComponent.setVisible(!visibilityToggleableComponent.isVisible())),
                 new Button("Close", window::close)

--- a/src/test/java/com/googlecode/lanterna/gui2/GridLayoutTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/GridLayoutTest.java
@@ -34,35 +34,35 @@ public class GridLayoutTest extends TestBase {
 
         Panel leftGridPanel = new Panel();
         leftGridPanel.setLayoutManager(new GridLayout(4));
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, new TerminalSize(4, 2)));
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLUE, new TerminalSize(4, 2)));
-        EmptySpace visibilityToggleableComponent = new EmptySpace(TextColor.ANSI.CYAN, new TerminalSize(4, 2));
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, TerminalSize.of(4, 2)));
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLUE, TerminalSize.of(4, 2)));
+        EmptySpace visibilityToggleableComponent = new EmptySpace(TextColor.ANSI.CYAN, TerminalSize.of(4, 2));
         leftGridPanel.addComponent(visibilityToggleableComponent);
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.GREEN, new TerminalSize(4, 2)));
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.GREEN, TerminalSize.of(4, 2)));
 
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.MAGENTA, new TerminalSize(4, 2))
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.MAGENTA, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.BEGINNING, GridLayout.Alignment.CENTER, true, false, 4, 1)));
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.RED, new TerminalSize(4, 2))
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.RED, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.CENTER, true, false, 4, 1)));
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.YELLOW, new TerminalSize(4, 2))
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.YELLOW, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.END, GridLayout.Alignment.CENTER, true, false, 4, 1)));
-        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, new TerminalSize(4, 2))
+        leftGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.FILL, GridLayout.Alignment.CENTER, true, false, 4, 1)));
 
         Panel rightGridPanel = new Panel();
         rightGridPanel.setLayoutManager(new GridLayout(5));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, new TerminalSize(4, 2)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.MAGENTA, new TerminalSize(4, 2))
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, TerminalSize.of(4, 2)));
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.MAGENTA, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.BEGINNING, false, true, 1, 4)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.RED, new TerminalSize(4, 2))
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.RED, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.CENTER, false, true, 1, 4)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.YELLOW, new TerminalSize(4, 2))
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.YELLOW, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.END, false, true, 1, 4)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, new TerminalSize(4, 2))
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLACK, TerminalSize.of(4, 2))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.FILL, false, true, 1, 4)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLUE, new TerminalSize(4, 2)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.CYAN, new TerminalSize(4, 2)));
-        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.GREEN, new TerminalSize(4, 2)));
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.BLUE, TerminalSize.of(4, 2)));
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.CYAN, TerminalSize.of(4, 2)));
+        rightGridPanel.addComponent(new EmptySpace(TextColor.ANSI.GREEN, TerminalSize.of(4, 2)));
 
         Panel contentPanel = new Panel();
         contentPanel.setLayoutManager(new LinearLayout(Direction.VERTICAL));

--- a/src/test/java/com/googlecode/lanterna/gui2/ImageComponentTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ImageComponentTest.java
@@ -197,7 +197,7 @@ public class ImageComponentTest extends TestBase {
     
     
     ImageComponent makeImageComponent(ExampleController controller, String[] image) {
-        TerminalSize imageSize = new TerminalSize(image[0].length(), image.length);
+        TerminalSize imageSize = TerminalSize.of(image[0].length(), image.length);
         TextImage textImage = new BasicTextImage(imageSize);
         for (int row = 0; row < image.length; row++) {
             fillImageLine(textImage, row, image[row]);

--- a/src/test/java/com/googlecode/lanterna/gui2/InputUITest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/InputUITest.java
@@ -73,7 +73,7 @@ public class InputUITest extends TestBase {
 
                     @Override
                     public TerminalSize getPreferredSize(Component component) {
-                        return new TerminalSize(70, 5);
+                        return TerminalSize.of(70, 5);
                     }
 
                     @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/InputUITest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/InputUITest.java
@@ -68,7 +68,7 @@ public class InputUITest extends TestBase {
                     @Override
                     public TerminalPosition getCursorLocation(Component component) {
                         TerminalSize adjustedSize = component.getSize().withRelative(-1, -1);
-                        return new TerminalPosition(adjustedSize.getColumns(), adjustedSize.getRows());
+                        return TerminalPosition.of(adjustedSize.getColumns(), adjustedSize.getRows());
                     }
 
                     @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/LineWrappingLabelTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/LineWrappingLabelTest.java
@@ -48,7 +48,7 @@ public class LineWrappingLabelTest extends TestBase {
     private TerminalSize windowSize;
 
     public LineWrappingLabelTest() {
-        windowSize = new TerminalSize(70, 15);
+        windowSize = TerminalSize.of(70, 15);
     }
 
     @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/ListBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ListBoxTest.java
@@ -38,7 +38,7 @@ public class ListBoxTest extends TestBase {
         Panel horizontalPanel = new Panel();
         horizontalPanel.setLayoutManager(new LinearLayout(Direction.HORIZONTAL));
 
-        TerminalSize size = new TerminalSize(14, 10);
+        TerminalSize size = TerminalSize.of(14, 10);
         CheckBoxList<String> checkBoxList = new CheckBoxList<>(size);
         RadioBoxList<String> radioBoxList = new RadioBoxList<>(size);
         ActionListBox actionListBox = new ActionListBox(size);

--- a/src/test/java/com/googlecode/lanterna/gui2/MenuTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MenuTest.java
@@ -109,7 +109,7 @@ public class MenuTest extends TestBase {
             return new ComponentRenderer<MultiColorComponent>() {
                 @Override
                 public TerminalSize getPreferredSize(MultiColorComponent component) {
-                    return new TerminalSize(40, 15);
+                    return TerminalSize.of(40, 15);
                 }
 
                 @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/MiscComponentTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MiscComponentTest.java
@@ -41,8 +41,8 @@ public class MiscComponentTest extends TestBase {
         }
 
         Panel textBoxPanel = new Panel();
-        textBoxPanel.addComponent(Panels.horizontal(new Label("Normal:   "), new TextBox(new TerminalSize(12, 1), "Text")));
-        textBoxPanel.addComponent(Panels.horizontal(new Label("Password: "), new TextBox(new TerminalSize(12, 1), "Text").setMask('*')));
+        textBoxPanel.addComponent(Panels.horizontal(new Label("Normal:   "), new TextBox(TerminalSize.of(12, 1), "Text")));
+        textBoxPanel.addComponent(Panels.horizontal(new Label("Password: "), new TextBox(TerminalSize.of(12, 1), "Text").setMask('*')));
 
         Panel buttonPanel = new Panel();
         buttonPanel.addComponent(new Button("Enable spacing", () -> {
@@ -56,7 +56,7 @@ public class MiscComponentTest extends TestBase {
 
         Panel rightPanel = new Panel();
         textBoxPanel = new Panel();
-        TextBox readOnlyTextArea = new TextBox(new TerminalSize(16, 8));
+        TextBox readOnlyTextArea = new TextBox(TerminalSize.of(16, 8));
         readOnlyTextArea.setReadOnly(true);
         readOnlyTextArea.setText(TestUtils.downloadGPL());
         textBoxPanel.addComponent(readOnlyTextArea);

--- a/src/test/java/com/googlecode/lanterna/gui2/MultiButtonTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MultiButtonTest.java
@@ -38,7 +38,7 @@ public class MultiButtonTest {
             contentArea.addComponent(new Button("TRE"));
             contentArea.addComponent(new Button("Button"));
             contentArea.addComponent(new Button("Another button"));
-            contentArea.addComponent(new EmptySpace(new TerminalSize(5, 1)));
+            contentArea.addComponent(new EmptySpace(TerminalSize.of(5, 1)));
             //contentArea.addComponent(new Button("Here is a\nmulti-line\ntext segment that is using \\n"));
             contentArea.addComponent(new Button("OK", window::close));
 

--- a/src/test/java/com/googlecode/lanterna/gui2/MultiLabelTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MultiLabelTest.java
@@ -37,7 +37,7 @@ public class MultiLabelTest {
             contentArea.setLayoutManager(new LinearLayout(Direction.VERTICAL));
             contentArea.addComponent(new Label("This is a single line label"));
             contentArea.addComponent(new Label("This is another label on the second line"));
-            contentArea.addComponent(new EmptySpace(new TerminalSize(5, 1)));
+            contentArea.addComponent(new EmptySpace(TerminalSize.of(5, 1)));
             contentArea.addComponent(new Label("Here is a\nmulti-line\ntext segment that is using \\n"));
             Label label = new Label("We can change foreground color...");
             label.setForegroundColor(TextColor.ANSI.BLUE);
@@ -49,7 +49,7 @@ public class MultiLabelTest {
             label.addStyle(SGR.BOLD);
             label.addStyle(SGR.UNDERLINE);
             contentArea.addComponent(label);
-            contentArea.addComponent(new EmptySpace(new TerminalSize(5, 1)));
+            contentArea.addComponent(new EmptySpace(TerminalSize.of(5, 1)));
             contentArea.addComponent(new Label("Here is an animated label:"));
             contentArea.addComponent(AnimatedLabel.createClassicSpinningLine());
             contentArea.addComponent(new EmptySpace());

--- a/src/test/java/com/googlecode/lanterna/gui2/MultiWindowManagerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MultiWindowManagerTest.java
@@ -52,7 +52,7 @@ public class MultiWindowManagerTest extends TestBase {
             buttonToggleVirtualScreen.setLabel("Virtual Screen: " + (virtualScreenEnabled ? "Enabled" : "Disabled"));
         });
         contentArea.addComponent(buttonToggleVirtualScreen);
-        contentArea.addComponent(new EmptySpace(TerminalSize.ONE));
+        contentArea.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         contentArea.addComponent(new Button("Close", mainWindow::close));
         mainWindow.setComponent(contentArea);
         textGUI.addListener((textGUI1, keyStroke) -> {
@@ -121,12 +121,12 @@ public class MultiWindowManagerTest extends TestBase {
             Panel contentArea = new Panel();
             contentArea.setLayoutManager(new GridLayout(1));
             contentArea.addComponent(statsTableContainer);
-            contentArea.addComponent(new EmptySpace(TerminalSize.ONE));
+            contentArea.addComponent(new EmptySpace(TerminalSize.OF_1x1));
             contentArea.addComponent(
                     new Label(
                             "Move window with ALT+Arrow\n" +
                             "Resize window with CTRL+Arrow"));
-            contentArea.addComponent(new EmptySpace(TerminalSize.ONE).setLayoutData(
+            contentArea.addComponent(new EmptySpace(TerminalSize.OF_1x1).setLayoutData(
                     GridLayout.createLayoutData(GridLayout.Alignment.FILL, GridLayout.Alignment.FILL, true, true)));
             contentArea.addComponent(
                     Panels.horizontal(
@@ -204,7 +204,7 @@ public class MultiWindowManagerTest extends TestBase {
             return new ComponentRenderer<EmptySpace>() {
                 @Override
                 public TerminalSize getPreferredSize(EmptySpace component) {
-                    return TerminalSize.ONE;
+                    return TerminalSize.OF_1x1;
                 }
 
                 @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/ScrollBarTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ScrollBarTest.java
@@ -70,12 +70,12 @@ public class ScrollBarTest extends TestBase {
         controlPanel.addComponent(new Label("Vertical view size:")).addComponent(textBoxVerticalSize);
         controlPanel.addComponent(new Label("Vertical scroll position:")).addComponent(textBoxVerticalPosition);
         controlPanel.addComponent(new Label("Vertical scroll max:")).addComponent(textBoxVerticalMax);
-        controlPanel.addComponent(new EmptySpace(TerminalSize.ONE)).addComponent(new EmptySpace(TerminalSize.ONE));
+        controlPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1)).addComponent(new EmptySpace(TerminalSize.OF_1x1));
         controlPanel.addComponent(new Label("Horizontal tracker grows:")).addComponent(checkHorizontalTrackerGrow);
         controlPanel.addComponent(new Label("Horizontal view size:")).addComponent(textBoxHorizontalSize);
         controlPanel.addComponent(new Label("Horizontal scroll position:")).addComponent(textBoxHorizontalPosition);
         controlPanel.addComponent(new Label("Horizontal scroll max:")).addComponent(textBoxHorizontalMax);
-        controlPanel.addComponent(new EmptySpace(TerminalSize.ONE)).addComponent(new EmptySpace(TerminalSize.ONE));
+        controlPanel.addComponent(new EmptySpace(TerminalSize.OF_1x1)).addComponent(new EmptySpace(TerminalSize.OF_1x1));
         controlPanel.addComponent(buttonRefresh);
         contentPanel.addComponent(closeButton);
 

--- a/src/test/java/com/googlecode/lanterna/gui2/SplitPanelTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/SplitPanelTest.java
@@ -122,14 +122,14 @@ public class SplitPanelTest extends TestBase {
         ImageComponent right = makeImageComponent(IMAGE_Y);
         //SplitPanel splitH = SplitPanel.ofHorizontal(left.withBorder(Borders.singleLine("left")), right.withBorder(Borders.singleLine("right")));
         SplitPanel splitH = SplitPanel.ofHorizontal(left, right);
-        splitH.setPreferredSize(new TerminalSize(40, 40));
+        splitH.setPreferredSize(TerminalSize.of(40, 40));
         splitH.setRatio(45, 35);
         
         ImageComponent top = makeImageComponent(IMAGE_Y);
         ImageComponent bottom = makeImageComponent(IMAGE_Z);
         //SplitPanel splitV = SplitPanel.ofVertical(top.withBorder(Borders.singleLine("top")), bottom.withBorder(Borders.singleLine("bottom")));
         SplitPanel splitV = SplitPanel.ofVertical(top, bottom);
-        splitV.setPreferredSize(new TerminalSize(40, 40));
+        splitV.setPreferredSize(TerminalSize.of(40, 40));
         splitV.setRatio(20, 80);
         
         Panel mainPanel = new Panel();
@@ -143,7 +143,7 @@ public class SplitPanelTest extends TestBase {
     
     ImageComponent makeImageComponent(String[] image) {
         ImageComponent imageComponent = new ImageComponent();
-        TerminalSize imageSize = new TerminalSize(image[0].length(), image.length);
+        TerminalSize imageSize = TerminalSize.of(image[0].length(), image.length);
         TextImage textImage = new BasicTextImage(imageSize);
         
         for (int row = 0; row < image.length; row++) {

--- a/src/test/java/com/googlecode/lanterna/gui2/TableUnitTests.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/TableUnitTests.java
@@ -24,7 +24,7 @@ public class TableUnitTests {
 
     @Before
     public void setUp() throws IOException {
-        TerminalSize size = new TerminalSize(30, 24);
+        TerminalSize size = TerminalSize.of(30, 24);
         terminal = new DefaultVirtualTerminal(size);
         TerminalScreen screen = new TerminalScreen(terminal);
         screen.startScreen();

--- a/src/test/java/com/googlecode/lanterna/gui2/TextBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/TextBoxTest.java
@@ -37,10 +37,10 @@ public class TextBoxTest extends TestBase {
 
         leftPanel.addComponent(new TextBox().withBorder(Borders.singleLine("Default")));
         leftPanel.addComponent(new TextBox("Some text").withBorder(Borders.singleLine("With init")));
-        leftPanel.addComponent(new TextBox(new TerminalSize(10, 1), "Here is some text that is too long to fit in the text box").withBorder(Borders.singleLine("Long text")));
+        leftPanel.addComponent(new TextBox(TerminalSize.of(10, 1), "Here is some text that is too long to fit in the text box").withBorder(Borders.singleLine("Long text")));
         leftPanel.addComponent(new TextBox("password").setMask('*').withBorder(Borders.singleLine("Password")));
 
-        rightPanel.addComponent(new TextBox(new TerminalSize(15, 5),
+        rightPanel.addComponent(new TextBox(TerminalSize.of(15, 5),
                 "Well here we are again\n" +
                 "It's always such a pleasure\n" +
                 "Remember when you tried\n" +

--- a/src/test/java/com/googlecode/lanterna/gui2/ThemeTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ThemeTest.java
@@ -63,7 +63,7 @@ public class ThemeTest extends TestBase {
         mainPanel.addComponent(new EmptySpace());
         ThemedComponentTestDialog[] componentTestDialogs = new ThemedComponentTestDialog[]{
                 new ThemedComponentTestDialog(textGUI, "ActionListBox",
-                        new ActionListBox(new TerminalSize(15, 5))
+                        new ActionListBox(TerminalSize.of(15, 5))
                                 .addItem(new NullRunnable("Item #1"))
                                 .addItem(new NullRunnable("Item #2"))
                                 .addItem(new NullRunnable("Item #3"))
@@ -80,16 +80,16 @@ public class ThemeTest extends TestBase {
                 new ThemedComponentTestDialog(textGUI, "Borders",
                         new Panel()
                                 .setLayoutManager(new GridLayout(4))
-                                .addComponent(new EmptySpace(new TerminalSize(4, 2)).withBorder(Borders.singleLine()))
-                                .addComponent(new EmptySpace(new TerminalSize(4, 2)).withBorder(Borders.singleLineBevel()))
-                                .addComponent(new EmptySpace(new TerminalSize(4, 2)).withBorder(Borders.doubleLine()))
-                                .addComponent(new EmptySpace(new TerminalSize(4, 2)).withBorder(Borders.doubleLineBevel()))),
+                                .addComponent(new EmptySpace(TerminalSize.of(4, 2)).withBorder(Borders.singleLine()))
+                                .addComponent(new EmptySpace(TerminalSize.of(4, 2)).withBorder(Borders.singleLineBevel()))
+                                .addComponent(new EmptySpace(TerminalSize.of(4, 2)).withBorder(Borders.doubleLine()))
+                                .addComponent(new EmptySpace(TerminalSize.of(4, 2)).withBorder(Borders.doubleLineBevel()))),
                 new ThemedComponentTestDialog(textGUI, "Button",
                         new Button("This is a button")),
                 new ThemedComponentTestDialog(textGUI, "CheckBox",
                         new CheckBox("This is a checkbox")),
                 new ThemedComponentTestDialog(textGUI, "CheckBoxList",
-                        new CheckBoxList<String>(new TerminalSize(15, 5))
+                        new CheckBoxList<String>(TerminalSize.of(15, 5))
                                 .addItem("Item #1")
                                 .addItem("Item #2")
                                 .addItem("Item #3")
@@ -102,15 +102,15 @@ public class ThemeTest extends TestBase {
                         new Panel()
                                 .addComponent(new ComboBox<>("Editable", "Item #2", "Item #3", "Item #4", "Item #5", "Item #6", "Item #7")
                                         .setReadOnly(false)
-                                        .setPreferredSize(new TerminalSize(12, 1)))
+                                        .setPreferredSize(TerminalSize.of(12, 1)))
                                 .addComponent(new EmptySpace())
                                 .addComponent(new ComboBox<>("Read-only", "Item #2", "Item #3", "Item #4", "Item #5", "Item #6", "Item #7")
                                         .setReadOnly(true)
-                                        .setPreferredSize(new TerminalSize(12, 1)))),
+                                        .setPreferredSize(TerminalSize.of(12, 1)))),
                 new ThemedComponentTestDialog(textGUI, "Label",
                         new Label("This is a label")),
                 new ThemedComponentTestDialog(textGUI, "RadioBoxList",
-                        new RadioBoxList<String>(new TerminalSize(15, 5))
+                        new RadioBoxList<String>(TerminalSize.of(15, 5))
                                 .addItem("Item #1")
                                 .addItem("Item #2")
                                 .addItem("Item #3")
@@ -126,13 +126,13 @@ public class ThemeTest extends TestBase {
                 new ThemedComponentTestDialog(textGUI, "ScrollBar",
                         new Panel()
                                 .setLayoutManager(new GridLayout(2))
-                                .addComponent(new ScrollBar(Direction.HORIZONTAL).setPreferredSize(new TerminalSize(6, 1)))
-                                .addComponent(new ScrollBar(Direction.VERTICAL).setPreferredSize(new TerminalSize(1, 6)))),
+                                .addComponent(new ScrollBar(Direction.HORIZONTAL).setPreferredSize(TerminalSize.of(6, 1)))
+                                .addComponent(new ScrollBar(Direction.VERTICAL).setPreferredSize(TerminalSize.of(1, 6)))),
                 new ThemedComponentTestDialog(textGUI, "Separator",
                         new Panel()
                                 .setLayoutManager(new GridLayout(2))
-                                .addComponent(new Separator(Direction.HORIZONTAL).setPreferredSize(new TerminalSize(6, 1)))
-                                .addComponent(new Separator(Direction.VERTICAL).setPreferredSize(new TerminalSize(1, 6)))),
+                                .addComponent(new Separator(Direction.HORIZONTAL).setPreferredSize(TerminalSize.of(6, 1)))
+                                .addComponent(new Separator(Direction.VERTICAL).setPreferredSize(TerminalSize.of(1, 6)))),
                 new ThemedComponentTestDialog(textGUI, "Table",
                         new Table<String>("Column #1", "Column #2", "Column #3")
                                 .setTableModel(
@@ -146,20 +146,20 @@ public class ThemeTest extends TestBase {
                                 .addComponent(
                                         Panels.horizontal(
                                                 new TextBox("Single-line text box")
-                                                        .setPreferredSize(new TerminalSize(15, 1)),
+                                                        .setPreferredSize(TerminalSize.of(15, 1)),
                                                 new TextBox("Single-line read-only")
-                                                        .setPreferredSize(new TerminalSize(15, 1))
+                                                        .setPreferredSize(TerminalSize.of(15, 1))
                                                         .setReadOnly(true)))
                                 .addComponent(new EmptySpace())
                                 .addComponent(
                                         Panels.horizontal(
-                                            new TextBox(new TerminalSize(15, 5), "Multi\nline\ntext\nbox\nHere is a very long line that doesn't fit")
+                                            new TextBox(TerminalSize.of(15, 5), "Multi\nline\ntext\nbox\nHere is a very long line that doesn't fit")
                                                     .setVerticalFocusSwitching(false),
-                                            new TextBox(new TerminalSize(15, 5), "Multi\nline\nread-only\ntext\nbox\n" +
+                                            new TextBox(TerminalSize.of(15, 5), "Multi\nline\nread-only\ntext\nbox\n" +
                                                     "Here is a very long line that doesn't fit")
                                                     .setReadOnly(true))))
         };
-        ActionListBox listBox = new ActionListBox(new TerminalSize(15, 7)).setLayoutData(LinearLayout.createLayoutData(LinearLayout.Alignment.CENTER));
+        ActionListBox listBox = new ActionListBox(TerminalSize.of(15, 7)).setLayoutData(LinearLayout.createLayoutData(LinearLayout.Alignment.CENTER));
         for(ThemedComponentTestDialog themedComponentTestDialog: componentTestDialogs) {
             listBox.addItem(themedComponentTestDialog);
         }
@@ -283,8 +283,8 @@ public class ThemeTest extends TestBase {
         window2.setTheme(LanternaThemes.getRegisteredTheme(themes.get(windowThemeIndex[1])));
         window2.setPosition(TerminalPosition.of(30, 1));
 
-        final Panel leftHolder = new Panel().setPreferredSize(new TerminalSize(15, 4));
-        final Panel rightHolder = new Panel().setPreferredSize(new TerminalSize(15, 4));
+        final Panel leftHolder = new Panel().setPreferredSize(TerminalSize.of(15, 4));
+        final Panel rightHolder = new Panel().setPreferredSize(TerminalSize.of(15, 4));
         GridLayout layoutManager = new GridLayout(1);
         leftHolder.setLayoutManager(layoutManager);
         rightHolder.setLayoutManager(layoutManager);

--- a/src/test/java/com/googlecode/lanterna/gui2/ThemeTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ThemeTest.java
@@ -276,12 +276,12 @@ public class ThemeTest extends TestBase {
         final BasicWindow window1 = new BasicWindow("Theme: bigsnake");
         window1.setHints(Collections.singletonList(Window.Hint.FIXED_POSITION));
         window1.setTheme(LanternaThemes.getRegisteredTheme(themes.get(windowThemeIndex[0])));
-        window1.setPosition(new TerminalPosition(2, 1));
+        window1.setPosition(TerminalPosition.of(2, 1));
 
         final BasicWindow window2 = new BasicWindow("Theme: conqueror");
         window2.setHints(Collections.singletonList(Window.Hint.FIXED_POSITION));
         window2.setTheme(LanternaThemes.getRegisteredTheme(themes.get(windowThemeIndex[1])));
-        window2.setPosition(new TerminalPosition(30, 1));
+        window2.setPosition(TerminalPosition.of(30, 1));
 
         final Panel leftHolder = new Panel().setPreferredSize(new TerminalSize(15, 4));
         final Panel rightHolder = new Panel().setPreferredSize(new TerminalSize(15, 4));

--- a/src/test/java/com/googlecode/lanterna/gui2/WelcomeSplashTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/WelcomeSplashTest.java
@@ -43,7 +43,7 @@ public class WelcomeSplashTest extends TestBase {
                 return new ComponentRenderer<EmptySpace>() {
                     @Override
                     public TerminalSize getPreferredSize(EmptySpace component) {
-                        return TerminalSize.ONE;
+                        return TerminalSize.OF_1x1;
                     }
 
                     @Override

--- a/src/test/java/com/googlecode/lanterna/gui2/WindowManagerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/WindowManagerTest.java
@@ -40,7 +40,7 @@ public class WindowManagerTest extends TestBase {
             super.prepareWindow(screenSize, window);
 
             window.setDecoratedSize(window.getPreferredSize().withRelative(12, 10));
-            window.setPosition(new TerminalPosition(
+            window.setPosition(TerminalPosition.of(
                     screenSize.getColumns() - window.getDecoratedSize().getColumns() - 1,
                     screenSize.getRows() - window.getDecoratedSize().getRows() - 1
             ));

--- a/src/test/java/com/googlecode/lanterna/gui2/WindowManagerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/WindowManagerTest.java
@@ -23,7 +23,7 @@ public class WindowManagerTest extends TestBase {
         final Window mainWindow = new BasicWindow("Window Manager Test");
         Panel contentArea = new Panel();
         contentArea.setLayoutManager(new LinearLayout(Direction.VERTICAL));
-        contentArea.addComponent(new EmptySpace(TerminalSize.ONE));
+        contentArea.addComponent(new EmptySpace(TerminalSize.OF_1x1));
         contentArea.addComponent(new Button("Close", new Runnable() {
             @Override
             public void run() {

--- a/src/test/java/com/googlecode/lanterna/issue/Issue190.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue190.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 public class Issue190 {
     public static void main(String[] args) throws IOException {
         DefaultTerminalFactory factory = new DefaultTerminalFactory();
-        factory.setInitialTerminalSize(new TerminalSize(150,50));
+        factory.setInitialTerminalSize(TerminalSize.of(150,50));
         factory.setTerminalEmulatorTitle("name");
         Terminal terminal = factory.createTerminal();
         TerminalScreen screen = new TerminalScreen(terminal);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue216.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue216.java
@@ -52,7 +52,7 @@ public class Issue216 {
         tableModel.addRow("hi");
         panel.addComponent(table);
 
-        panel.addComponent(new EmptySpace(new TerminalSize(0,0))); // Empty space underneath labels
+        panel.addComponent(new EmptySpace(TerminalSize.of(0,0))); // Empty space underneath labels
         panel.addComponent(new Button("Submit", () -> {
             tableModel.addRow("haiiii");
             //table.invalidate();

--- a/src/test/java/com/googlecode/lanterna/issue/Issue261.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue261.java
@@ -47,7 +47,7 @@ public class Issue261 {
         panel.addComponent(new Label("Surname"));
         panel.addComponent(new TextBox());
 
-        panel.addComponent(new EmptySpace(new TerminalSize(0,0))); // Empty space underneath labels
+        panel.addComponent(new EmptySpace(TerminalSize.of(0,0))); // Empty space underneath labels
         panel.addComponent(new Button("Submit"));
 
         // Create gui and start gui
@@ -55,7 +55,7 @@ public class Issue261 {
 
         // Create window to hold the panel
         BasicWindow window = new BasicWindow();
-        window.setFixedSize(new TerminalSize(500, 700));
+        window.setFixedSize(TerminalSize.of(500, 700));
         window.setComponent(panel);
 
         gui.addWindowAndWait(window);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue274.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue274.java
@@ -36,7 +36,7 @@ public class Issue274 {
         Panel menubar = new Panel();
         menubar.setLayoutManager(new LinearLayout(Direction.HORIZONTAL).setSpacing(1));
 
-        TextBox text = new TextBox(new TerminalSize(10,10),TextBox.Style.MULTI_LINE);
+        TextBox text = new TextBox(TerminalSize.of(10,10),TextBox.Style.MULTI_LINE);
         menubar.addComponent(text);
 
         menubar.addComponent(new Button("Open", () -> {

--- a/src/test/java/com/googlecode/lanterna/issue/Issue384.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue384.java
@@ -23,7 +23,7 @@ public class Issue384 {
         final MultiWindowTextGUI textGUI = new MultiWindowTextGUI(screen);
         final Window window = new BasicWindow("Table container test");
         window.setHints(Collections.singletonList(Window.Hint.FIXED_SIZE));
-        window.setFixedSize(new TerminalSize(60, 14));
+        window.setFixedSize(TerminalSize.of(60, 14));
 
         final Table<String> table = new Table<>("Column", "Expanded Column", "Column");
         table.setCellSelection(true);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue387.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue387.java
@@ -30,9 +30,9 @@ public class Issue387 {
 
             Panel panel = new Panel();
             panel.addComponent(new TextBox());
-            panel.addComponent(new EmptySpace(new TerminalSize(15, 1)));
+            panel.addComponent(new EmptySpace(TerminalSize.of(15, 1)));
             panel.addComponent(table);
-            panel.addComponent(new EmptySpace(new TerminalSize(15, 1)));
+            panel.addComponent(new EmptySpace(TerminalSize.of(15, 1)));
             panel.addComponent(new TextBox());
 
             window.setComponent(panel);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue409.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue409.java
@@ -93,7 +93,7 @@ public class Issue409 {
 
         public CyclingThemesTextBox() {
             super("Cycling themes: default");
-            setPreferredSize(new TerminalSize(40, 1));
+            setPreferredSize(TerminalSize.of(40, 1));
             systemThemes = new ArrayList<>(LanternaThemes.getRegisteredThemes());
             index = 0;
         }

--- a/src/test/java/com/googlecode/lanterna/issue/Issue452.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue452.java
@@ -66,7 +66,7 @@ public class Issue452 {
 
     public static void main(String[] args) throws IOException {
         try (Screen screen = new DefaultTerminalFactory().setTelnetPort(23000)
-                .setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG_MOVE).setInitialTerminalSize(new TerminalSize(100, 100))
+                .setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG_MOVE).setInitialTerminalSize(TerminalSize.of(100, 100))
                 .createScreen()) {
             screen.startScreen();
             WindowBasedTextGUI gui = new MultiWindowTextGUI(screen);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
@@ -65,7 +65,7 @@ public class Issue452Test {
     void displayForRenderering(Component component) throws Exception {
         // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
         // making use of the drawing routines in the renderer to know the size this thing is
-        Terminal terminal = new DefaultVirtualTerminal(new TerminalSize(100, 100));
+        Terminal terminal = new DefaultVirtualTerminal(TerminalSize.of(100, 100));
         TerminalScreen screen = new TerminalScreen(terminal);
         screen.startScreen();
         WindowBasedTextGUI textGUI = new MultiWindowTextGUI(screen);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
@@ -55,7 +55,7 @@ public class Issue452Test {
         content = new Panel(new GridLayout(GRID_WIDTH));
         GridLayout gridLayout = (GridLayout) content.getLayoutManager();
         gridLayout.setVerticalSpacing(1);
-        window.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+        window.setPosition(TerminalPosition.OF_0x0);
         window.setComponent(content);
     }
 
@@ -269,7 +269,7 @@ public class Issue452Test {
      * Clicks at position
      */
     private MouseAction clickAt(int column, int row) {
-        return new MouseAction(MouseActionType.CLICK_DOWN, 1, new TerminalPosition(column, row));
+        return new MouseAction(MouseActionType.CLICK_DOWN, 1, TerminalPosition.of(column, row));
     }
 
     /**

--- a/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
@@ -41,11 +41,11 @@ public class DrawImageTest {
         TextGraphics textGraphics = image.newTextGraphics();
         textGraphics.drawRectangle(
                 TerminalPosition.OF_0x0,
-                new TerminalSize(5, 5),
+                TerminalSize.of(5, 5),
                 imageCharacter.withBackgroundColor(TextColor.ANSI.RED));
         textGraphics.drawRectangle(
                 TerminalPosition.OF_1x1,
-                new TerminalSize(3, 3),
+                TerminalSize.of(3, 3),
                 imageCharacter.withBackgroundColor(TextColor.ANSI.MAGENTA));
         textGraphics.setCharacter(2, 2,
                 imageCharacter.withBackgroundColor(TextColor.ANSI.CYAN));

--- a/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
@@ -68,7 +68,7 @@ public class DrawImageTest {
         screenGraphics.drawImage(TerminalPosition.of(1, 7), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(10));
 
         //0 size should draw nothing
-        screenGraphics.drawImage(TerminalPosition.of(8, 7), image, TerminalPosition.of(0, 0), TerminalSize.ZERO);
+        screenGraphics.drawImage(TerminalPosition.of(8, 7), image, TerminalPosition.of(0, 0), TerminalSize.OF_0x0);
 
         //Drawing with a negative source image offset will move the target position
         screenGraphics.drawImage(TerminalPosition.of(8, 7), image, TerminalPosition.of(-2, -2), image.getSize());

--- a/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/DrawImageTest.java
@@ -40,11 +40,11 @@ public class DrawImageTest {
         TextCharacter imageCharacter = new TextCharacter('X');
         TextGraphics textGraphics = image.newTextGraphics();
         textGraphics.drawRectangle(
-                TerminalPosition.TOP_LEFT_CORNER,
+                TerminalPosition.OF_0x0,
                 new TerminalSize(5, 5),
                 imageCharacter.withBackgroundColor(TextColor.ANSI.RED));
         textGraphics.drawRectangle(
-                TerminalPosition.OFFSET_1x1,
+                TerminalPosition.OF_1x1,
                 new TerminalSize(3, 3),
                 imageCharacter.withBackgroundColor(TextColor.ANSI.MAGENTA));
         textGraphics.setCharacter(2, 2,
@@ -53,25 +53,25 @@ public class DrawImageTest {
         TextGraphics screenGraphics = screen.newTextGraphics();
         screenGraphics.setBackgroundColor(TextColor.Indexed.fromRGB(50, 50, 50));
         screenGraphics.fill(' ');
-        screenGraphics.drawImage(TerminalPosition.OFFSET_1x1, image);
-        screenGraphics.drawImage(new TerminalPosition(8, 1), image, TerminalPosition.TOP_LEFT_CORNER, image.getSize().withRelativeColumns(-4));
-        screenGraphics.drawImage(new TerminalPosition(10, 1), image, TerminalPosition.TOP_LEFT_CORNER, image.getSize().withRelativeColumns(-3));
-        screenGraphics.drawImage(new TerminalPosition(13, 1), image, TerminalPosition.TOP_LEFT_CORNER, image.getSize().withRelativeColumns(-2));
-        screenGraphics.drawImage(new TerminalPosition(17, 1), image, TerminalPosition.TOP_LEFT_CORNER, image.getSize().withRelativeColumns(-1));
-        screenGraphics.drawImage(new TerminalPosition(22, 1), image);
-        screenGraphics.drawImage(new TerminalPosition(28, 1), image, new TerminalPosition(1, 0), image.getSize());
-        screenGraphics.drawImage(new TerminalPosition(33, 1), image, new TerminalPosition(2, 0), image.getSize());
-        screenGraphics.drawImage(new TerminalPosition(37, 1), image, new TerminalPosition(3, 0), image.getSize());
-        screenGraphics.drawImage(new TerminalPosition(40, 1), image, new TerminalPosition(4, 0), image.getSize());
+        screenGraphics.drawImage(TerminalPosition.of(1, 1), image);
+        screenGraphics.drawImage(TerminalPosition.of(8, 1), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(-4));
+        screenGraphics.drawImage(TerminalPosition.of(10, 1), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(-3));
+        screenGraphics.drawImage(TerminalPosition.of(13, 1), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(-2));
+        screenGraphics.drawImage(TerminalPosition.of(17, 1), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(-1));
+        screenGraphics.drawImage(TerminalPosition.of(22, 1), image);
+        screenGraphics.drawImage(TerminalPosition.of(28, 1), image, TerminalPosition.of(1, 0), image.getSize());
+        screenGraphics.drawImage(TerminalPosition.of(33, 1), image, TerminalPosition.of(2, 0), image.getSize());
+        screenGraphics.drawImage(TerminalPosition.of(37, 1), image, TerminalPosition.of(3, 0), image.getSize());
+        screenGraphics.drawImage(TerminalPosition.of(40, 1), image, TerminalPosition.of(4, 0), image.getSize());
 
         //Try to draw bigger than the image size, this should ignore the extra size
-        screenGraphics.drawImage(new TerminalPosition(1, 7), image, TerminalPosition.TOP_LEFT_CORNER, image.getSize().withRelativeColumns(10));
+        screenGraphics.drawImage(TerminalPosition.of(1, 7), image, TerminalPosition.of(0, 0), image.getSize().withRelativeColumns(10));
 
         //0 size should draw nothing
-        screenGraphics.drawImage(new TerminalPosition(8, 7), image, TerminalPosition.TOP_LEFT_CORNER, TerminalSize.ZERO);
+        screenGraphics.drawImage(TerminalPosition.of(8, 7), image, TerminalPosition.of(0, 0), TerminalSize.ZERO);
 
         //Drawing with a negative source image offset will move the target position
-        screenGraphics.drawImage(new TerminalPosition(8, 7), image, new TerminalPosition(-2, -2), image.getSize());
+        screenGraphics.drawImage(TerminalPosition.of(8, 7), image, TerminalPosition.of(-2, -2), image.getSize());
 
         screen.refresh();
         screen.readInput();

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenLineTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenLineTest.java
@@ -74,9 +74,9 @@ public class ScreenLineTest {
             TerminalPosition p1;
             TerminalPosition p2;
             if(circle) {
-                p1 = new TerminalPosition(size.getColumns() / 2, size.getRows() / 2);
+                p1 = TerminalPosition.of(size.getColumns() / 2, size.getRows() / 2);
                 if(CIRCLE_LAST_POSITION == null) {
-                    CIRCLE_LAST_POSITION = new TerminalPosition(0, 0);
+                    CIRCLE_LAST_POSITION = TerminalPosition.of(0, 0);
                 }
                 else if(CIRCLE_LAST_POSITION.getRow() == 0) {
                     if(CIRCLE_LAST_POSITION.getColumn() < size.getColumns() - 1) {
@@ -105,8 +105,8 @@ public class ScreenLineTest {
                 p2 = CIRCLE_LAST_POSITION;
             }
             else {
-                p1 = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
-                p2 = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+                p1 = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+                p2 = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
             }
             textGraphics.setBackgroundColor(color);
             textGraphics.drawLine(p1, p2, ' ');

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenRectangleTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenRectangleTest.java
@@ -72,7 +72,7 @@ public class ScreenRectangleTest {
                 color = new TextColor.Indexed(random.nextInt(256));
             }
 
-            TerminalPosition topLeft = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+            TerminalPosition topLeft = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
             TerminalSize rectangleSize = new TerminalSize(random.nextInt(size.getColumns() - topLeft.getColumn()), random.nextInt(size.getRows() - topLeft.getRow()));
 
             textGraphics.setBackgroundColor(color);

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenRectangleTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenRectangleTest.java
@@ -73,7 +73,7 @@ public class ScreenRectangleTest {
             }
 
             TerminalPosition topLeft = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
-            TerminalSize rectangleSize = new TerminalSize(random.nextInt(size.getColumns() - topLeft.getColumn()), random.nextInt(size.getRows() - topLeft.getRow()));
+            TerminalSize rectangleSize = TerminalSize.of(random.nextInt(size.getColumns() - topLeft.getColumn()), random.nextInt(size.getRows() - topLeft.getRow()));
 
             textGraphics.setBackgroundColor(color);
             if(useFilled) {

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenResizeTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenResizeTest.java
@@ -40,7 +40,7 @@ public class ScreenResizeTest {
     public ScreenResizeTest(String[] args) throws InterruptedException, IOException {
         screen = new TestTerminalFactory(args).createScreen();
         screen.startScreen();
-        screen.setCursorPosition(new TerminalPosition(0, 0));
+        screen.setCursorPosition(TerminalPosition.of(0, 0));
         putStrings("Initial setup, please resize the window");
 
         long now = System.currentTimeMillis();

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenTabTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenTabTest.java
@@ -38,7 +38,7 @@ public class ScreenTabTest {
     public ScreenTabTest(String[] args) throws InterruptedException, IOException {
         screen = new TestTerminalFactory(args).createScreen();
         screen.startScreen();
-        screen.setCursorPosition(new TerminalPosition(0, 0));
+        screen.setCursorPosition(TerminalPosition.of(0, 0));
         putStrings("Trying out some tabs!");
 
         long now = System.currentTimeMillis();
@@ -80,16 +80,16 @@ public class ScreenTabTest {
         screen.refresh();
 
         //Verify
-        if(!screen.getBackCharacter(new TerminalPosition(20, 11)).is(' ')) {
+        if(!screen.getBackCharacter(TerminalPosition.of(20, 11)).is(' ')) {
             throw new IllegalStateException("Expected tab to be replaced with space");
         }
-        if(!screen.getBackCharacter(new TerminalPosition(21, 11)).is('X')) {
+        if(!screen.getBackCharacter(TerminalPosition.of(21, 11)).is('X')) {
             throw new IllegalStateException("Expected X in back buffer");
         }
-        if(!screen.getFrontCharacter(new TerminalPosition(20, 11)).is(' ')) {
+        if(!screen.getFrontCharacter(TerminalPosition.of(20, 11)).is(' ')) {
             throw new IllegalStateException("Expected tab to be replaced with space");
         }
-        if(!screen.getFrontCharacter(new TerminalPosition(21, 11)).is('X')) {
+        if(!screen.getFrontCharacter(TerminalPosition.of(21, 11)).is('X')) {
             throw new IllegalStateException("Expected X in front buffer");
         }
     }

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenTriangleTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenTriangleTest.java
@@ -104,15 +104,15 @@ public class ScreenTriangleTest {
                 int y1 = (size.getRows() / 2) + (int) (Math.sin(rad + oneThirdOf2PI) * triangleSize);
                 int x2 = (size.getColumns() / 2) + (int) (Math.cos(rad + twoThirdsOf2PI) * triangleSize);
                 int y2 = (size.getRows() / 2) + (int) (Math.sin(rad + twoThirdsOf2PI) * triangleSize);
-                p1 = new TerminalPosition(x0, y0);
-                p2 = new TerminalPosition(x1, y1);
-                p3 = new TerminalPosition(x2, y2);
+                p1 = TerminalPosition.of(x0, y0);
+                p2 = TerminalPosition.of(x1, y1);
+                p3 = TerminalPosition.of(x2, y2);
                 rad += Math.PI / 90.0;
             }
             else {
-                p1 = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
-                p2 = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
-                p3 = new TerminalPosition(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+                p1 = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+                p2 = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
+                p3 = TerminalPosition.of(random.nextInt(size.getColumns()), random.nextInt(size.getRows()));
             }
 
             graphics.setBackgroundColor(color);

--- a/src/test/java/com/googlecode/lanterna/screen/VirtualScreenTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/VirtualScreenTest.java
@@ -44,9 +44,9 @@ public class VirtualScreenTest {
 
         TextGraphics textGraphics = screen.newTextGraphics();
         textGraphics.setBackgroundColor(TextColor.ANSI.GREEN);
-        textGraphics.fillTriangle(new TerminalPosition(40, 0), new TerminalPosition(25,19), new TerminalPosition(65, 19), ' ');
+        textGraphics.fillTriangle(TerminalPosition.of(40, 0), TerminalPosition.of(25,19), TerminalPosition.of(65, 19), ' ');
         textGraphics.setBackgroundColor(TextColor.ANSI.RED);
-        textGraphics.drawRectangle(TerminalPosition.TOP_LEFT_CORNER, screen.getTerminalSize(), ' ');
+        textGraphics.drawRectangle(TerminalPosition.OF_0x0, screen.getTerminalSize(), ' ');
         screen.refresh();
 
         while(true) {

--- a/src/test/java/com/googlecode/lanterna/terminal/KeyTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/KeyTest.java
@@ -32,28 +32,28 @@ public class KeyTest {
         {
             KeyStroke k = KeyStroke.fromString("a");
             assertEquals(KeyType.CHARACTER, k.getKeyType());
-            assertEquals(new Character('a'), k.getCharacter());
+            assertEquals(Character.valueOf('a'), k.getCharacter());
             assertFalse(k.isCtrlDown());
             assertFalse(k.isAltDown());
         }
         {
             KeyStroke k = KeyStroke.fromString("<c-a>");
             assertEquals(KeyType.CHARACTER, k.getKeyType());
-            assertEquals(new Character('a'), k.getCharacter());
+            assertEquals(Character.valueOf('a'), k.getCharacter());
             assertTrue(k.isCtrlDown());
             assertFalse(k.isAltDown());
         }
         {
             KeyStroke k = KeyStroke.fromString("<a-a>");
             assertEquals(KeyType.CHARACTER, k.getKeyType());
-            assertEquals(new Character('a'), k.getCharacter());
+            assertEquals(Character.valueOf('a'), k.getCharacter());
             assertFalse(k.isCtrlDown());
             assertTrue(k.isAltDown());
         }
         {
             KeyStroke k = KeyStroke.fromString("<c-a-a>");
             assertEquals(k.getKeyType(), KeyType.CHARACTER);
-            assertEquals(new Character('a'), k.getCharacter());
+            assertEquals(Character.valueOf('a'), k.getCharacter());
             assertTrue(k.isCtrlDown());
             assertTrue(k.isAltDown());
         }

--- a/src/test/java/com/googlecode/lanterna/terminal/SimpleTerminalTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/SimpleTerminalTest.java
@@ -159,7 +159,7 @@ public class SimpleTerminalTest {
     }
 
     private static TerminalPosition resetCursorPositionAfterHelp(Terminal terminal) throws IOException {
-        TerminalPosition cursorPosition = new TerminalPosition(0, 10);
+        TerminalPosition cursorPosition = TerminalPosition.of(0, 10);
         terminal.setCursorPosition(cursorPosition.getColumn(), cursorPosition.getRow());
         return cursorPosition;
     }

--- a/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
@@ -40,7 +40,7 @@ public class TerminalTextGraphicsTest {
         textGraphics.setForegroundColor(TextColor.ANSI.BLUE);
         textGraphics.putString(3, 3, "Hello World!");
         textGraphics.setForegroundColor(TextColor.ANSI.CYAN);
-        TerminalPosition lineStart = new TerminalPosition(3 + "Hello World!".length(), 3);
+        TerminalPosition lineStart = TerminalPosition.of(3 + "Hello World!".length(), 3);
         textGraphics.drawLine(lineStart, lineStart.withRelativeColumn(2).withRelativeRow(6), Symbols.BLOCK_SOLID);
         textGraphics.setForegroundColor(TextColor.ANSI.RED);
         textGraphics.drawRectangle(lineStart.withRelativeColumn(2).withRelativeRow(6), new TerminalSize(5, 3), Symbols.BULLET);
@@ -52,9 +52,9 @@ public class TerminalTextGraphicsTest {
                 triangleStart.withColumn(5).withRelativeRow(3),
                 Symbols.SPADES);
         textGraphics.setForegroundColor(TextColor.ANSI.YELLOW);
-        textGraphics.fillRectangle(new TerminalPosition(30, 1), new TerminalSize(8, 5), Symbols.DIAMOND);
+        textGraphics.fillRectangle(TerminalPosition.of(30, 1), new TerminalSize(8, 5), Symbols.DIAMOND);
         textGraphics.setForegroundColor(TextColor.ANSI.GREEN);
-        triangleStart = new TerminalPosition(30, 6);
+        triangleStart = TerminalPosition.of(30, 6);
         textGraphics.fillTriangle(
                 triangleStart,
                 triangleStart.withRelativeRow(5).withRelativeColumn(-2),

--- a/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
@@ -43,7 +43,7 @@ public class TerminalTextGraphicsTest {
         TerminalPosition lineStart = TerminalPosition.of(3 + "Hello World!".length(), 3);
         textGraphics.drawLine(lineStart, lineStart.withRelativeColumn(2).withRelativeRow(6), Symbols.BLOCK_SOLID);
         textGraphics.setForegroundColor(TextColor.ANSI.RED);
-        textGraphics.drawRectangle(lineStart.withRelativeColumn(2).withRelativeRow(6), new TerminalSize(5, 3), Symbols.BULLET);
+        textGraphics.drawRectangle(lineStart.withRelativeColumn(2).withRelativeRow(6), TerminalSize.of(5, 3), Symbols.BULLET);
         textGraphics.setForegroundColor(TextColor.ANSI.MAGENTA);
         TerminalPosition triangleStart = lineStart.withRelativeColumn(7).withRelativeRow(9);
         textGraphics.drawTriangle(
@@ -52,7 +52,7 @@ public class TerminalTextGraphicsTest {
                 triangleStart.withColumn(5).withRelativeRow(3),
                 Symbols.SPADES);
         textGraphics.setForegroundColor(TextColor.ANSI.YELLOW);
-        textGraphics.fillRectangle(TerminalPosition.of(30, 1), new TerminalSize(8, 5), Symbols.DIAMOND);
+        textGraphics.fillRectangle(TerminalPosition.of(30, 1), TerminalSize.of(8, 5), Symbols.DIAMOND);
         textGraphics.setForegroundColor(TextColor.ANSI.GREEN);
         triangleStart = TerminalPosition.of(30, 6);
         textGraphics.fillTriangle(

--- a/src/test/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminalTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminalTest.java
@@ -40,7 +40,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void initialTerminalStateIsAsExpected() {
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         TerminalSize terminalSize = virtualTerminal.getTerminalSize();
         assertEquals(new TerminalSize(80, 24), terminalSize);
 
@@ -59,7 +59,7 @@ public class DefaultVirtualTerminalTest {
         }
         assertLineEquals(testString, 0);
         assertLineEquals("", 1);
-        assertEquals(new TerminalPosition(testString.length(), 0), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(testString.length(), 0), virtualTerminal.getCursorPosition());
     }
 
     @Test
@@ -79,31 +79,31 @@ public class DefaultVirtualTerminalTest {
         for(int i = 0; i < toPrint.length; i++) {
             assertLineEquals(toPrint[i], i);
         }
-        assertEquals(new TerminalPosition(0, toPrint.length), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, toPrint.length), virtualTerminal.getCursorPosition());
     }
 
     @Test
     public void singleLineWriteAndReadBackWorks() {
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
         virtualTerminal.putCharacter(new TextCharacter('O'));
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER.withColumn(5), virtualTerminal.getCursorPosition());
-        assertEquals('H', virtualTerminal.getCharacter(new TerminalPosition(0, 0)).getCharacterString().charAt(0));
-        assertEquals('E', virtualTerminal.getCharacter(new TerminalPosition(1, 0)).getCharacterString().charAt(0));
-        assertEquals('L', virtualTerminal.getCharacter(new TerminalPosition(2, 0)).getCharacterString().charAt(0));
-        assertEquals('L', virtualTerminal.getCharacter(new TerminalPosition(3, 0)).getCharacterString().charAt(0));
-        assertEquals('O', virtualTerminal.getCharacter(new TerminalPosition(4, 0)).getCharacterString().charAt(0));
+        assertEquals(TerminalPosition.OF_0x0.withColumn(5), virtualTerminal.getCursorPosition());
+        assertEquals('H', virtualTerminal.getCharacter(TerminalPosition.of(0, 0)).getCharacterString().charAt(0));
+        assertEquals('E', virtualTerminal.getCharacter(TerminalPosition.of(1, 0)).getCharacterString().charAt(0));
+        assertEquals('L', virtualTerminal.getCharacter(TerminalPosition.of(2, 0)).getCharacterString().charAt(0));
+        assertEquals('L', virtualTerminal.getCharacter(TerminalPosition.of(3, 0)).getCharacterString().charAt(0));
+        assertEquals('O', virtualTerminal.getCharacter(TerminalPosition.of(4, 0)).getCharacterString().charAt(0));
 
         assertFalse(virtualTerminal.isWholeBufferDirtyThenReset());
         assertEquals(new TreeSet<>(Arrays.asList(
-                new TerminalPosition(0, 0),
-                new TerminalPosition(1, 0),
-                new TerminalPosition(2, 0),
-                new TerminalPosition(3, 0),
-                new TerminalPosition(4, 0))),
+                TerminalPosition.of(0, 0),
+                TerminalPosition.of(1, 0),
+                TerminalPosition.of(2, 0),
+                TerminalPosition.of(3, 0),
+                TerminalPosition.of(4, 0))),
                 virtualTerminal.getAndResetDirtyCells());
 
         // Make sure it's reset
@@ -113,7 +113,7 @@ public class DefaultVirtualTerminalTest {
     @Test
     public void clearAllMarksEverythingAsDirtyAndEverythingInTheTerminalIsReplacedWithDefaultCharacter() {
         virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
@@ -124,18 +124,18 @@ public class DefaultVirtualTerminalTest {
         assertTrue(virtualTerminal.isWholeBufferDirtyThenReset());
         assertEquals(Collections.emptySet(), virtualTerminal.getAndResetDirtyCells());
 
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(0, 0)));
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(1, 0)));
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(2, 0)));
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(3, 0)));
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(4, 0)));
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(0, 0)));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(1, 0)));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(2, 0)));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(3, 0)));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(4, 0)));
     }
 
     @Test
     public void replacingAllContentTriggersWholeTerminalIsDirty() {
         virtualTerminal.setTerminalSize(new TerminalSize(5, 3));
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
@@ -158,14 +158,14 @@ public class DefaultVirtualTerminalTest {
     @Test
     public void tooLongLinesWrap() {
         virtualTerminal.setTerminalSize(new TerminalSize(5, 5));
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
         virtualTerminal.putCharacter(new TextCharacter('L'));
         virtualTerminal.putCharacter(new TextCharacter('O'));
         virtualTerminal.putCharacter(new TextCharacter('!'));
-        assertEquals(TerminalPosition.OFFSET_1x1, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_1x1, virtualTerminal.getCursorPosition());
 
         // Expected layout:
         // |HELLO|
@@ -176,14 +176,14 @@ public class DefaultVirtualTerminalTest {
     @Test
     public void makeSureDoubleWidthCharactersWrapProperly() {
         virtualTerminal.setTerminalSize(new TerminalSize(9, 5));
-        assertEquals(TerminalPosition.TOP_LEFT_CORNER, virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('こ'));
         virtualTerminal.putCharacter(new TextCharacter('ん'));
         virtualTerminal.putCharacter(new TextCharacter('に'));
         virtualTerminal.putCharacter(new TextCharacter('ち'));
         virtualTerminal.putCharacter(new TextCharacter('は'));
         virtualTerminal.putCharacter(new TextCharacter('!'));
-        assertEquals(new TerminalPosition(3, 1), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(3, 1), virtualTerminal.getCursorPosition());
 
         // Expected layout:
         // |こんにち|
@@ -191,7 +191,7 @@ public class DefaultVirtualTerminalTest {
         // where the cursor is one column after the '!' (2 + 1 = 3rd column)
 
         // Make sure there's a default padding character at 8x0
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(8, 0)));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(8, 0)));
     }
 
     @Test
@@ -200,22 +200,22 @@ public class DefaultVirtualTerminalTest {
         virtualTerminal.putCharacter(new TextCharacter('画'));
         virtualTerminal.putCharacter(new TextCharacter('面'));
 
-        assertEquals('画', virtualTerminal.getCharacter(new TerminalPosition(0, 0)).getCharacterString().charAt(0));
-        assertEquals('画', virtualTerminal.getCharacter(new TerminalPosition(1, 0)).getCharacterString().charAt(0));
-        assertEquals('面', virtualTerminal.getCharacter(new TerminalPosition(2, 0)).getCharacterString().charAt(0));
-        assertEquals('面', virtualTerminal.getCharacter(new TerminalPosition(3, 0)).getCharacterString().charAt(0));
+        assertEquals('画', virtualTerminal.getCharacter(TerminalPosition.of(0, 0)).getCharacterString().charAt(0));
+        assertEquals('画', virtualTerminal.getCharacter(TerminalPosition.of(1, 0)).getCharacterString().charAt(0));
+        assertEquals('面', virtualTerminal.getCharacter(TerminalPosition.of(2, 0)).getCharacterString().charAt(0));
+        assertEquals('面', virtualTerminal.getCharacter(TerminalPosition.of(3, 0)).getCharacterString().charAt(0));
 
-        virtualTerminal.setCursorPosition(new TerminalPosition(0, 0));
+        virtualTerminal.setCursorPosition(TerminalPosition.of(0, 0));
         virtualTerminal.putCharacter(new TextCharacter('Y'));
 
-        assertEquals('Y', virtualTerminal.getCharacter(new TerminalPosition(0, 0)).getCharacterString().charAt(0));
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(1, 0)));
+        assertEquals('Y', virtualTerminal.getCharacter(TerminalPosition.of(0, 0)).getCharacterString().charAt(0));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(1, 0)));
 
-        virtualTerminal.setCursorPosition(new TerminalPosition(3, 0));
+        virtualTerminal.setCursorPosition(TerminalPosition.of(3, 0));
         virtualTerminal.putCharacter(new TextCharacter('V'));
 
-        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(new TerminalPosition(2, 0)));
-        assertEquals('V', virtualTerminal.getCharacter(new TerminalPosition(3, 0)).getCharacterString().charAt(0));
+        assertEquals(TextCharacter.DEFAULT_CHARACTER, virtualTerminal.getCharacter(TerminalPosition.of(2, 0)));
+        assertEquals('V', virtualTerminal.getCharacter(TerminalPosition.of(3, 0)).getCharacterString().charAt(0));
     }
 
     @Test
@@ -223,31 +223,31 @@ public class DefaultVirtualTerminalTest {
         virtualTerminal.setTerminalSize(new TerminalSize(3, 3));
         virtualTerminal.putCharacter('\n');
         virtualTerminal.putCharacter('\n');
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('\n');
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('\n');
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
 
         // Shrink viewport
         virtualTerminal.setTerminalSize(new TerminalSize(3, 2));
-        assertEquals(new TerminalPosition(0, 1), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 1), virtualTerminal.getCursorPosition());
 
         // Restore
         virtualTerminal.setTerminalSize(new TerminalSize(3, 3));
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
 
         // Enlarge
         virtualTerminal.setTerminalSize(new TerminalSize(3, 4));
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorPosition());
         virtualTerminal.setTerminalSize(new TerminalSize(3, 5));
-        assertEquals(new TerminalPosition(0, 4), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
 
         // We've reached the total size of the buffer, enlarging it further shouldn't affect the cursor position
         virtualTerminal.setTerminalSize(new TerminalSize(3, 6));
-        assertEquals(new TerminalPosition(0, 4), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
         virtualTerminal.setTerminalSize(new TerminalSize(3, 7));
-        assertEquals(new TerminalPosition(0, 4), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
     }
 
     @Test
@@ -256,7 +256,7 @@ public class DefaultVirtualTerminalTest {
         // Backlog of 1, meaning viewport size + 1 row
         virtualTerminal.setBacklogSize(1);
         putString("Line 1\n");
-        assertEquals(new TerminalPosition(0, 1), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 1), virtualTerminal.getCursorPosition());
         assertEquals(virtualTerminal.getCursorPosition(), virtualTerminal.getCursorBufferPosition());
         putString("Line 2\n");
         putString("Line 3\n");
@@ -276,8 +276,8 @@ public class DefaultVirtualTerminalTest {
         assertLineEquals("Line 3", 0);
         assertLineEquals("Line 4", 1);
         assertLineEquals("", 2);
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorBufferPosition());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorBufferPosition());
 
         // Make terminal bigger
         virtualTerminal.setTerminalSize(new TerminalSize(10, 4));
@@ -287,8 +287,8 @@ public class DefaultVirtualTerminalTest {
         assertLineEquals("Line 3", 1);
         assertLineEquals("Line 4", 2);
         assertLineEquals("", 3);
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorPosition());
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorBufferPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorBufferPosition());
 
         // Make it even bigger
         virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
@@ -300,8 +300,8 @@ public class DefaultVirtualTerminalTest {
         assertLineEquals("Line 4", 2);
         assertLineEquals("", 3);
         assertLineEquals("", 4);
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorPosition());
-        assertEquals(new TerminalPosition(0, 3), virtualTerminal.getCursorBufferPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorBufferPosition());
     }
 
     @Test
@@ -309,9 +309,9 @@ public class DefaultVirtualTerminalTest {
         virtualTerminal.setTerminalSize(new TerminalSize(80, 3));
         virtualTerminal.setBacklogSize(0);
         virtualTerminal.putCharacter(fromChar('A'));
-        virtualTerminal.setCursorPosition(new TerminalPosition(1, 1));
+        virtualTerminal.setCursorPosition(TerminalPosition.of(1, 1));
         virtualTerminal.putCharacter(fromChar('B'));
-        virtualTerminal.setCursorPosition(new TerminalPosition(2, 2));
+        virtualTerminal.setCursorPosition(TerminalPosition.of(2, 2));
         virtualTerminal.putCharacter(fromChar('C'));
 
         assertLineEquals("A", 0);
@@ -320,19 +320,19 @@ public class DefaultVirtualTerminalTest {
 
         // Dirty positions should now be these
         assertEquals(new TreeSet<>(Arrays.asList(
-                new TerminalPosition(0, 0),
-                new TerminalPosition(1, 1),
-                new TerminalPosition(2, 2))), virtualTerminal.getDirtyCells());
-        assertEquals(new TerminalPosition(3, 2), virtualTerminal.getCursorPosition());
+                TerminalPosition.of(0, 0),
+                TerminalPosition.of(1, 1),
+                TerminalPosition.of(2, 2))), virtualTerminal.getDirtyCells());
+        assertEquals(TerminalPosition.of(3, 2), virtualTerminal.getCursorPosition());
 
         // Add one more row to shift out the first line
         virtualTerminal.putCharacter('\n');
 
         // Dirty positions should now be adjusted
         assertEquals(new TreeSet<>(Arrays.asList(
-                new TerminalPosition(1, 0),
-                new TerminalPosition(2, 1))), virtualTerminal.getDirtyCells());
-        assertEquals(new TerminalPosition(0, 2), virtualTerminal.getCursorPosition());
+                TerminalPosition.of(1, 0),
+                TerminalPosition.of(2, 1))), virtualTerminal.getDirtyCells());
+        assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
     }
 
     @Test
@@ -342,12 +342,12 @@ public class DefaultVirtualTerminalTest {
         for(int i = 1; i <= ROWS + 2; i++) {
             putString("Line " + i + "\n");
         }
-        assertEquals(new TerminalPosition(0, ROWS - 1), virtualTerminal.getCursorPosition());
-        assertEquals(new TerminalPosition(0, ROWS + 2), virtualTerminal.getCursorBufferPosition());
+        assertEquals(TerminalPosition.of(0, ROWS - 1), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, ROWS + 2), virtualTerminal.getCursorBufferPosition());
 
         virtualTerminal.enterPrivateMode();
-        assertEquals(new TerminalPosition(0, 0), virtualTerminal.getCursorPosition());
-        assertEquals(new TerminalPosition(0, 0), virtualTerminal.getCursorBufferPosition());
+        assertEquals(TerminalPosition.of(0, 0), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 0), virtualTerminal.getCursorBufferPosition());
         for(int i = 0; i < ROWS; i++) {
             assertLineEquals("", i);
         }
@@ -519,26 +519,26 @@ public class DefaultVirtualTerminalTest {
     public void settingCursorOutsideOfTerminalWindowWillBeAdjusted() {
         virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
         virtualTerminal.setCursorPosition(20, 10);
-        assertEquals(new TerminalPosition(9, 4), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(9, 4), virtualTerminal.getCursorPosition());
 
         virtualTerminal.setCursorPosition(0, 10);
-        assertEquals(new TerminalPosition(0, 4), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
 
         virtualTerminal.setCursorPosition(20, 0);
-        assertEquals(new TerminalPosition(9, 0), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(9, 0), virtualTerminal.getCursorPosition());
     }
 
     @Test
     public void puttingCharacterInLastColumnDoesntMoveCursorToNextLine() {
         virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
         virtualTerminal.setCursorPosition(8, 2);
-        assertEquals(new TerminalPosition(8, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(8, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('A');
-        assertEquals(new TerminalPosition(9, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(9, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('B');
-        assertEquals(new TerminalPosition(10, 2), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(10, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('C');
-        assertEquals(new TerminalPosition(1, 3), virtualTerminal.getCursorPosition());
+        assertEquals(TerminalPosition.of(1, 3), virtualTerminal.getCursorPosition());
         assertEquals(DEFAULT_CHARACTER.withCharacter('C'), virtualTerminal.getCharacter(0, 3));
     }
 
@@ -568,7 +568,7 @@ public class DefaultVirtualTerminalTest {
     private void assertBufferLineEquals(String expectedBufferLineContent, int rowNumber) {
         int column = 0;
         for(char c: expectedBufferLineContent.toCharArray()) {
-            assertEquals(DEFAULT_CHARACTER.withCharacter(c), virtualTerminal.getBufferCharacter(new TerminalPosition(column++, rowNumber)));
+            assertEquals(DEFAULT_CHARACTER.withCharacter(c), virtualTerminal.getBufferCharacter(TerminalPosition.of(column++, rowNumber)));
             if(TerminalTextUtils.isCharDoubleWidth(c)) {
                 column++;
             }

--- a/src/test/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminalTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminalTest.java
@@ -42,7 +42,7 @@ public class DefaultVirtualTerminalTest {
     public void initialTerminalStateIsAsExpected() {
         assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         TerminalSize terminalSize = virtualTerminal.getTerminalSize();
-        assertEquals(new TerminalSize(80, 24), terminalSize);
+        assertEquals(TerminalSize.of(80, 24), terminalSize);
 
         for(int row = 0; row < terminalSize.getRows(); row++) {
             for(int column = 0; column < terminalSize.getColumns(); column++) {
@@ -112,7 +112,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void clearAllMarksEverythingAsDirtyAndEverythingInTheTerminalIsReplacedWithDefaultCharacter() {
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 5));
         assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
@@ -134,7 +134,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void replacingAllContentTriggersWholeTerminalIsDirty() {
-        virtualTerminal.setTerminalSize(new TerminalSize(5, 3));
+        virtualTerminal.setTerminalSize(TerminalSize.of(5, 3));
         assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
@@ -157,7 +157,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void tooLongLinesWrap() {
-        virtualTerminal.setTerminalSize(new TerminalSize(5, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(5, 5));
         assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('H'));
         virtualTerminal.putCharacter(new TextCharacter('E'));
@@ -175,7 +175,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void makeSureDoubleWidthCharactersWrapProperly() {
-        virtualTerminal.setTerminalSize(new TerminalSize(9, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(9, 5));
         assertEquals(TerminalPosition.OF_0x0, virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter(new TextCharacter('こ'));
         virtualTerminal.putCharacter(new TextCharacter('ん'));
@@ -196,7 +196,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void overwritingDoubleWidthCharactersEraseTheOtherHalf() {
-        virtualTerminal.setTerminalSize(new TerminalSize(5, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(5, 5));
         virtualTerminal.putCharacter(new TextCharacter('画'));
         virtualTerminal.putCharacter(new TextCharacter('面'));
 
@@ -220,7 +220,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void testCursorPositionUpdatesWhenTerminalSizeChanges() {
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 3));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 3));
         virtualTerminal.putCharacter('\n');
         virtualTerminal.putCharacter('\n');
         assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
@@ -230,29 +230,29 @@ public class DefaultVirtualTerminalTest {
         assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
 
         // Shrink viewport
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 2));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 2));
         assertEquals(TerminalPosition.of(0, 1), virtualTerminal.getCursorPosition());
 
         // Restore
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 3));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 3));
         assertEquals(TerminalPosition.of(0, 2), virtualTerminal.getCursorPosition());
 
         // Enlarge
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 4));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 4));
         assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorPosition());
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 5));
         assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
 
         // We've reached the total size of the buffer, enlarging it further shouldn't affect the cursor position
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 6));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 6));
         assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
-        virtualTerminal.setTerminalSize(new TerminalSize(3, 7));
+        virtualTerminal.setTerminalSize(TerminalSize.of(3, 7));
         assertEquals(TerminalPosition.of(0, 4), virtualTerminal.getCursorPosition());
     }
 
     @Test
     public void textScrollingOutOfTheBacklogDisappears() {
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 3));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 3));
         // Backlog of 1, meaning viewport size + 1 row
         virtualTerminal.setBacklogSize(1);
         putString("Line 1\n");
@@ -280,7 +280,7 @@ public class DefaultVirtualTerminalTest {
         assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorBufferPosition());
 
         // Make terminal bigger
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 4));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 4));
 
         // Now "Line 2" should be the top row
         assertLineEquals("Line 2", 0);
@@ -291,7 +291,7 @@ public class DefaultVirtualTerminalTest {
         assertEquals(TerminalPosition.of(0, 3), virtualTerminal.getCursorBufferPosition());
 
         // Make it even bigger
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 5));
 
         // Should make no difference, the viewport will add an empty row at the end, because there is nothing in the
         // backlog to insert at the top
@@ -306,7 +306,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void backlogTrimmingAdjustsCursorPositionAndDirtyCells() {
-        virtualTerminal.setTerminalSize(new TerminalSize(80, 3));
+        virtualTerminal.setTerminalSize(TerminalSize.of(80, 3));
         virtualTerminal.setBacklogSize(0);
         virtualTerminal.putCharacter(fromChar('A'));
         virtualTerminal.setCursorPosition(TerminalPosition.of(1, 1));
@@ -338,7 +338,7 @@ public class DefaultVirtualTerminalTest {
     @Test
     public void testPrivateMode() {
         final int ROWS = 5;
-        virtualTerminal.setTerminalSize(new TerminalSize(20, ROWS));
+        virtualTerminal.setTerminalSize(TerminalSize.of(20, ROWS));
         for(int i = 1; i <= ROWS + 2; i++) {
             putString("Line " + i + "\n");
         }
@@ -372,7 +372,7 @@ public class DefaultVirtualTerminalTest {
     @Test
     public void testForEachLine() {
         final int ROWS = 40;
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 5));
         for(int i = 1; i <= ROWS; i++) {
             putString("Line " + i + "\n");
         }
@@ -486,7 +486,7 @@ public class DefaultVirtualTerminalTest {
 
         virtualTerminal.flush();
         virtualTerminal.bell();
-        virtualTerminal.setTerminalSize(new TerminalSize(40, 10));
+        virtualTerminal.setTerminalSize(TerminalSize.of(40, 10));
         assertEquals(0, flushCounter.get());
         assertEquals(0, bellCounter.get());
         assertEquals(0, resizeCounter.get());
@@ -495,7 +495,7 @@ public class DefaultVirtualTerminalTest {
         virtualTerminal.addVirtualTerminalListener(listener);
         virtualTerminal.flush();
         virtualTerminal.bell();
-        virtualTerminal.setTerminalSize(new TerminalSize(80, 20));
+        virtualTerminal.setTerminalSize(TerminalSize.of(80, 20));
         assertEquals(1, flushCounter.get());
         assertEquals(1, bellCounter.get());
         assertEquals(1, resizeCounter.get());
@@ -507,7 +507,7 @@ public class DefaultVirtualTerminalTest {
         virtualTerminal.removeVirtualTerminalListener(listener);
         virtualTerminal.flush();
         virtualTerminal.bell();
-        virtualTerminal.setTerminalSize(new TerminalSize(40, 10));
+        virtualTerminal.setTerminalSize(TerminalSize.of(40, 10));
         virtualTerminal.close();
         assertEquals(1, flushCounter.get());
         assertEquals(1, bellCounter.get());
@@ -517,7 +517,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void settingCursorOutsideOfTerminalWindowWillBeAdjusted() {
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 5));
         virtualTerminal.setCursorPosition(20, 10);
         assertEquals(TerminalPosition.of(9, 4), virtualTerminal.getCursorPosition());
 
@@ -530,7 +530,7 @@ public class DefaultVirtualTerminalTest {
 
     @Test
     public void puttingCharacterInLastColumnDoesntMoveCursorToNextLine() {
-        virtualTerminal.setTerminalSize(new TerminalSize(10, 5));
+        virtualTerminal.setTerminalSize(TerminalSize.of(10, 5));
         virtualTerminal.setCursorPosition(8, 2);
         assertEquals(TerminalPosition.of(8, 2), virtualTerminal.getCursorPosition());
         virtualTerminal.putCharacter('A');

--- a/src/test/java/com/googlecode/lanterna/tutorial/Tutorial03.java
+++ b/src/test/java/com/googlecode/lanterna/tutorial/Tutorial03.java
@@ -124,7 +124,7 @@ public class Tutorial03 {
                     /*
                     We pick a random location
                      */
-                        TerminalPosition cellToModify = new TerminalPosition(
+                        TerminalPosition cellToModify = TerminalPosition.of(
                                 random.nextInt(terminalSize.getColumns()),
                                 random.nextInt(terminalSize.getRows()));
 
@@ -149,7 +149,7 @@ public class Tutorial03 {
                 box with information on the size of the terminal window
                  */
                 String sizeLabel = "Terminal Size: " + terminalSize;
-                TerminalPosition labelBoxTopLeft = new TerminalPosition(1, 1);
+                TerminalPosition labelBoxTopLeft = TerminalPosition.of(1, 1);
                 TerminalSize labelBoxSize = new TerminalSize(sizeLabel.length() + 2, 3);
                 TerminalPosition labelBoxTopRightCorner = labelBoxTopLeft.withRelativeColumn(labelBoxSize.getColumns() - 1);
                 TextGraphics textGraphics = screen.newTextGraphics();

--- a/src/test/java/com/googlecode/lanterna/tutorial/Tutorial03.java
+++ b/src/test/java/com/googlecode/lanterna/tutorial/Tutorial03.java
@@ -150,7 +150,7 @@ public class Tutorial03 {
                  */
                 String sizeLabel = "Terminal Size: " + terminalSize;
                 TerminalPosition labelBoxTopLeft = TerminalPosition.of(1, 1);
-                TerminalSize labelBoxSize = new TerminalSize(sizeLabel.length() + 2, 3);
+                TerminalSize labelBoxSize = TerminalSize.of(sizeLabel.length() + 2, 3);
                 TerminalPosition labelBoxTopRightCorner = labelBoxTopLeft.withRelativeColumn(labelBoxSize.getColumns() - 1);
                 TextGraphics textGraphics = screen.newTextGraphics();
                 //This isn't really needed as we are overwriting everything below anyway, but just for demonstrative purpose

--- a/src/test/java/com/googlecode/lanterna/tutorial/Tutorial04.java
+++ b/src/test/java/com/googlecode/lanterna/tutorial/Tutorial04.java
@@ -120,7 +120,7 @@ public class Tutorial04 {
             List<String> timezonesAsStrings = new ArrayList<>(Arrays.asList(TimeZone.getAvailableIDs()));
             ComboBox<String> readOnlyComboBox = new ComboBox<>(timezonesAsStrings);
             readOnlyComboBox.setReadOnly(true);
-            readOnlyComboBox.setPreferredSize(new TerminalSize(20, 1));
+            readOnlyComboBox.setPreferredSize(TerminalSize.of(20, 1));
             contentPanel.addComponent(readOnlyComboBox);
 
             contentPanel.addComponent(new Label("Editable Combo Box (filled)"));


### PR DESCRIPTION
Added classes: TestTerminalSize & TestTerminalPosition

Cleaned up and fixed some object memory churn situations

Changed to use TerminalSize.of() and TerminalPosition.of() rather than constructors directly which allows for the potential to add more memory management, for example could have small pool.

